### PR TITLE
MAINT: add mpmath as test dependency, add self as maintainer.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,6 +37,7 @@ requirements:
 test:
   requires:
     - nose
+    - mpmath
   imports:
     - scipy
     - scipy.integrate.vode
@@ -60,3 +61,4 @@ extra:
   recipe-maintainers:
     - jakirkham
     - msarahan
+    - rgommers

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -66,7 +66,6 @@ import scipy.special.specfun
 import scipy.stats._rank
 import scipy.stats.mvn
 import scipy.stats.statlib
-import scipy.stats.vonmises_cython
 
 import scipy.stats
 import scipy.special


### PR DESCRIPTION
Also remove ``stats.vonmises_cython`` as import in run_test.py, because
that extension module has been removed in scipy master and therefore
that import will give an issue with scipy 0.18.0 soon.