### PR TITLE
Try to use `clang++`

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -6,11 +6,31 @@
 # but it works fine to get our first build.
 unset LDFLAGS
 
+# FIXME: This is a hack to make sure the environment is activated.
+# The reason this is required is due to the conda-build issue
+# mentioned below.
+#
+# https://github.com/conda/conda-build/issues/910
+#
+source activate "${CONDA_DEFAULT_ENV}"
+
+
+export LIBRARY_PATH="${PREFIX}/lib"
+export C_INCLUDE_PATH="${PREFIX}/include"
+export CPLUS_INCLUDE_PATH="${PREFIX}/include"
+
 # Depending on our platform, shared libraries end with either .so or .dylib
 if [[ `uname` == 'Darwin' ]]; then
+    # Also, included a workaround so that `-stdlib=c++` doesn't go to
+    # `gfortran` and cause problems.
+    #
+    # https://github.com/conda-forge/toolchain-feedstock/pull/8
     DYLIB_EXT=dylib
+    export CFLAGS="${CFLAGS} -stdlib=libc++ -lc++"
+    export LDFLAGS="-headerpad_max_install_names -undefined dynamic_lookup -bundle -Wl,-search_paths_first -lc++"
 else
     DYLIB_EXT=so
+    unset LDFLAGS
 fi
 
 # If OpenBLAS is being used, we should be able to find the libraries.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
   md5: 8987b9a3e3cd79218a0a423b21c8e4de
 
 build:
-  number: 200
+  number: 201
   # We lack openblas on Windows, and therefore can't build scipy there either currently.
   skip: true  # [win]
   features:
@@ -21,6 +21,7 @@ build:
 
 requirements:
   build:
+    - toolchain
     - gcc
     - python
     - cython


### PR DESCRIPTION
This is an attempt to make sure `clang++` and `libc++` are used to build SciPy. As there are some C++ STL types being exposed and the rest of our stack using `clang++` and `libc++`, it is very important for SciPy to be compliant. However, this may be tricky given the requirement to have `gfortran`. Let's see what we can do.