### PR TITLE
Only ship libgfortran

### DIFF
--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -43,6 +43,14 @@ conda update --yes --all
 conda install --yes conda-build
 conda info
 
+
+# Install the yum requirements defined canonically in the
+# "recipe/yum_requirements.txt" file. After updating that file,
+# run "conda smithy rerender" and this line be updated
+# automatically.
+yum install -y devtoolset-2-gcc-gfortran
+
+
 # Embarking on 6 case(s).
     set -x
     export CONDA_NPY=110

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,14 +26,14 @@ requirements:
     - python
     - cython
     - blas 1.1 {{ variant }}
-    - libgfortran
+    - libgfortran  # [linux]
     - openblas  0.2.18*
     - numpy     x.x
   run:
     - python
     - blas 1.1 {{ variant }}
     - libgcc       # [osx]
-    - libgfortran  # [unix]
+    - libgfortran  # [linux]
     - openblas  0.2.18*
     - numpy     x.x
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,8 +32,7 @@ requirements:
   run:
     - python
     - blas 1.1 {{ variant }}
-    - libgcc       # [osx]
-    - libgfortran  # [linux]
+    - libgfortran
     - openblas  0.2.18*
     - numpy     x.x
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
   md5: 8987b9a3e3cd79218a0a423b21c8e4de
 
 build:
-  number: 201
+  number: 202
   # We lack openblas on Windows, and therefore can't build scipy there either currently.
   skip: true  # [win]
   features:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,16 +22,18 @@ build:
 requirements:
   build:
     - toolchain
-    - gcc
+    - gcc          # [osx]
     - python
     - cython
     - blas 1.1 {{ variant }}
+    - libgfortran
     - openblas  0.2.18*
     - numpy     x.x
   run:
-    - libgcc
     - python
     - blas 1.1 {{ variant }}
+    - libgcc       # [osx]
+    - libgfortran  # [unix]
     - openblas  0.2.18*
     - numpy     x.x
 

--- a/recipe/yum_requirements.txt
+++ b/recipe/yum_requirements.txt
@@ -1,0 +1,1 @@
+devtoolset-2-gcc-gfortran


### PR DESCRIPTION
Currently, we are shipping the whole `libgcc` package on Linux with `scipy`. This has proved problematic in our stack especially as was seen with `numpy` ( https://github.com/conda-forge/numpy-feedstock/issues/15 ). However, unlike with `openblas` we cannot simply just ship `libgfortran` as `scipy` has C++ code and thus depends on `libstdc++`. Given the shipping of `libstdc++` was the cause of the issues with code depending on `numpy`, it is tricky to find an easy fix here.

There are two main options to avoid shipping `libstdc++`. First, try to use `gfortran` and `libgfortran` from the `gcc` package only and otherwise use the image compilers and libraries. Second, try to use system compilers for the whole process, but have everything link to our `libgfortran` instead. Attempts to get the first point to work with `openblas` proved tricky and we were unable to get it to work. So, we are skipping that option and going for the second one instead. Hopefully we can evaluate the effectiveness of this strategy and move forward from there.