### PR TITLE
Unpin conda-build on Travis CI [ci skip]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
 
       conda config --set show_channel_urls true
       conda update --yes conda
-      conda install --yes conda-build=1.20.0 jinja2 anaconda-client
+      conda install --yes conda-build jinja2 anaconda-client
       conda config --add channels conda-forge
       
 


### PR DESCRIPTION
Not sure if we are going to need this or not. In some cases we have had bad symlinks getting packaged when using activation scripts (like those in the `toolchain`) like as shown in this issue ( https://github.com/conda-forge/hdf5-feedstock/issues/23 ). Though we haven't seen this problem crop up recently and are not totally sure why. There may have been a change in `conda` that has made this unnecessary, but we have been unable to confirm. So, am just readying this in case it is needed.

xref: https://github.com/conda-forge/scipy-feedstock/pull/2

cc @pelson @rgommers @gillins