### PR TITLE
Rebuild with parallel OpenBLAS

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -15,6 +15,11 @@ unset LDFLAGS
 source activate "${CONDA_DEFAULT_ENV}"
 
 
+# Use OpenBLAS with 1 thread only as it seems to be using too many
+# on the CIs apparently.
+export OPENBLAS_NUM_THREADS=1
+
+
 export LIBRARY_PATH="${PREFIX}/lib"
 export C_INCLUDE_PATH="${PREFIX}/include"
 export CPLUS_INCLUDE_PATH="${PREFIX}/include"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
   md5: 8987b9a3e3cd79218a0a423b21c8e4de
 
 build:
-  number: 202
+  number: 203
   # We lack openblas on Windows, and therefore can't build scipy there either currently.
   skip: true  # [win]
   features:

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -1,4 +1,9 @@
 import sys
+import os
+
+# Use OpenBLAS with 1 thread only as it seems to be using too many
+# on the CIs apparently.
+os.environ["OPENBLAS_NUM_THREADS"] = "1"
 
 import scipy
 import scipy.cluster._hierarchy


### PR DESCRIPTION
Bump build number and rebuild with the parallel OpenBLAS. Basically the same as PR ( https://github.com/conda-forge/scipy-feedstock/pull/6 ) for `0.17.x`. To see a use case for this rebuild, please see PRs ( https://github.com/conda-forge/pytmatrix-feedstock/pull/4 ), ( https://github.com/conda-forge/wradlib-feedstock/pull/16 ) where it appears `scipy` version `0.18.0` is not supported yet.

cc @ocefpaf @kmuehlbauer