### PR TITLE
Config SciPy v0.17 build with NumPy 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,8 @@ env:
   matrix:
     
     - CONDA_NPY=110  CONDA_PY=27
-    - CONDA_NPY=111  CONDA_PY=27
     - CONDA_NPY=110  CONDA_PY=34
-    - CONDA_NPY=111  CONDA_PY=34
     - CONDA_NPY=110  CONDA_PY=35
-    - CONDA_NPY=111  CONDA_PY=35
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "e7q3YO1EqC8H+r6P4zfX+qHo9BoWkTj5NWmdy/Qt2IqGcj1lX+StqJ3gtkokvzzhKNfIEnqSTU5J6YnzFolUzEWXOvTGvxYtUNB0c2FkqA5fmeYjFiJgROvAM3zwdBdn3i5iweTdt46JR/99SqD6Z6qv2swaNyyzreKpWg4DW8cC04vCtLJW84+nZ/TJwZ8JTnNpFpmUPZzKM4JaFjeR7eJcak+e7CoGgrER26pGC7qXCviSxw10But7/lYv8DWrnG5SIkrUpaA5i83NwZEbSbd+4FeSs5dxDwWCiKB7bLWCrmVkUwhPfj+6iGNMOTyW2GLxzzCYyWo5Hy7Z5bTjfJC+qjhQR20If1pPhyVvunzTK+zGxH4Wd4W0KLce02TmU/22JP6WmuzAOfymhREMvFqi6CgOMRvXAvxyBGbkFSaGW3BNE4bXxr02jeLuBq5kMRQSt1kjXschvjonFsdB7Fuvx3G78aQj9EW7bYSokdJzFBfGe4ur4D1vCoNrBr4Yf1Fk2uOy6hg/rrgznHxsMRn99wPh7V1Zp1iWUQOUaBg8Rurpwm9Nm3sjeAmteEJDDPH+D5DP9PYAq5NUVOW0lxvQQR9KBIxRWPcmryJW7r6ZxCeIfgnMzpGd29O0gSuCZZ+Wm7+jABeas4Anhg5bahAdaY8PyJbnoNYsPtMcrZM="
@@ -31,12 +28,10 @@ install:
       bash $MINICONDA_FILE -b
 
       export PATH=/Users/travis/miniconda3/bin:$PATH
-
-      conda config --set show_channel_urls true
-      conda update --yes conda
-      conda install --yes conda-build jinja2 anaconda-client
       conda config --add channels conda-forge
-      
+      conda config --set show_channel_urls true
+      conda install --yes --quiet conda-forge-build-setup
+      source run_conda_forge_build_setup
 
 script:
   - conda build ./recipe

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Feedstock license: BSD 3-Clause
 
 Summary: Scientific Library for Python
 
+SciPy is a Python-based ecosystem of open-source software for mathematics,
+science, and engineering.
 
 
 Installing scipy
@@ -38,7 +40,7 @@ About conda-forge
 
 conda-forge is a community-led conda channel of installable packages.
 In order to provide high-quality builds, the process has been automated into the
-conda-forge GitHub organization. The conda-forge organization contains one repository 
+conda-forge GitHub organization. The conda-forge organization contains one repository
 for each of the installable packages. Such a repository is known as a *feedstock*.
 
 A feedstock is made up of a conda recipe (the instructions on what and how to build
@@ -71,7 +73,7 @@ Current build status
 ====================
 
 Linux: [![Circle CI](https://circleci.com/gh/conda-forge/scipy-feedstock.svg?style=svg)](https://circleci.com/gh/conda-forge/scipy-feedstock)
-OSX: [![TravisCI](https://travis-ci.org/conda-forge/scipy-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/scipy-feedstock) 
+OSX: [![TravisCI](https://travis-ci.org/conda-forge/scipy-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/scipy-feedstock)
 Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/scipy-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/scipy-feedstock/branch/master)
 
 Current release info
@@ -92,7 +94,7 @@ install and use.
 
 In order to produce a uniquely identifiable distribution:
  * If the version of a package **is not** being increased, please add or increase
-   the [``build/number``](http://conda.pydata.org/docs/building/meta-yaml.html#build-number-and-string). 
+   the [``build/number``](http://conda.pydata.org/docs/building/meta-yaml.html#build-number-and-string).
  * If the version of a package **is** being increased, please remember to return
    the [``build/number``](http://conda.pydata.org/docs/building/meta-yaml.html#build-number-and-string)
    back to 0.

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -14,7 +14,6 @@ config=$(cat <<CONDARC
 
 channels:
  - conda-forge
-
  - defaults # As we need conda-build
 
 conda-build:
@@ -39,9 +38,8 @@ echo "$config" > ~/.condarc
 # A lock sometimes occurs with incomplete builds. The lock file is stored in build_artefacts.
 conda clean --lock
 
-conda update --yes --all
-conda install --yes conda-build
-conda info
+conda install --yes --quiet conda-forge-build-setup
+source run_conda_forge_build_setup
 
 
 # Install the yum requirements defined canonically in the
@@ -51,16 +49,9 @@ conda info
 yum install -y devtoolset-2-gcc-gfortran
 
 
-# Embarking on 6 case(s).
+# Embarking on 3 case(s).
     set -x
     export CONDA_NPY=110
-    export CONDA_PY=27
-    set +x
-    conda build /recipe_root --quiet || exit 1
-    /feedstock_root/ci_support/upload_or_check_non_existence.py /recipe_root conda-forge --channel=main || exit 1
-
-    set -x
-    export CONDA_NPY=111
     export CONDA_PY=27
     set +x
     conda build /recipe_root --quiet || exit 1
@@ -74,21 +65,7 @@ yum install -y devtoolset-2-gcc-gfortran
     /feedstock_root/ci_support/upload_or_check_non_existence.py /recipe_root conda-forge --channel=main || exit 1
 
     set -x
-    export CONDA_NPY=111
-    export CONDA_PY=34
-    set +x
-    conda build /recipe_root --quiet || exit 1
-    /feedstock_root/ci_support/upload_or_check_non_existence.py /recipe_root conda-forge --channel=main || exit 1
-
-    set -x
     export CONDA_NPY=110
-    export CONDA_PY=35
-    set +x
-    conda build /recipe_root --quiet || exit 1
-    /feedstock_root/ci_support/upload_or_check_non_existence.py /recipe_root conda-forge --channel=main || exit 1
-
-    set -x
-    export CONDA_NPY=111
     export CONDA_PY=35
     set +x
     conda build /recipe_root --quiet || exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
 build:
   number: 202
   # We lack openblas on Windows, and therefore can't build scipy there either currently.
-  skip: true  # [win]
+  skip: true  # [win or np!=110]
   features:
     - blas_{{ variant }}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
   md5: 8987b9a3e3cd79218a0a423b21c8e4de
 
 build:
-  number: 202
+  number: 203
   # We lack openblas on Windows, and therefore can't build scipy there either currently.
   skip: true  # [win or np!=110]
   features:


### PR DESCRIPTION
As it seems to be too much to build 2 NumPy versions and 3 Python versions on CircleCI, I'm proposing we break them up into 2 branches that build with 1 NumPy each. This should be well within the time limit. Think of this as a poor man's build matrix. In the long run, we will want to have some sort of build matrix support via CircleCI's parallelism feature as explained in issue ( https://github.com/conda-forge/conda-smithy/issues/203 ). However, after spending some time on it, it is clear to me this is going to take a bit more work. Unfortunately, I don't have the time to dedicate to that problem at present. So, I'm punting on it by breaking these up in the hopes of solving downstream package build issues seen in PRs ( https://github.com/conda-forge/pytmatrix-feedstock/pull/4 ) and ( https://github.com/conda-forge/wradlib-feedstock/pull/16 ) (potentially others). This includes the build number bump to force a rebuild around the parallel OpenBLAS. The NumPy 1.11 build can be seen in PR ( https://github.com/conda-forge/scipy-feedstock/pull/10 ).

cc @pelson @ocefpaf @kmuehlbauer