### PR TITLE
force add py34

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   matrix:
     
     - CONDA_PY=27
+    - CONDA_PY=34
     - CONDA_PY=35
     - CONDA_PY=36
   global:

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -65,9 +65,15 @@ source run_conda_forge_build_setup
 /usr/bin/sudo -n yum install -y devtoolset-2-gcc-gfortran
 
 
-# Embarking on 3 case(s).
+# Embarking on 4 case(s).
     set -x
     export CONDA_PY=27
+    set +x
+    conda build /recipe_root --quiet || exit 1
+    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+
+    set -x
+    export CONDA_PY=34
     set +x
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1


### PR DESCRIPTION
Adding Python 3.4 version of `scipy` for academic reasons. This can be removed in the next re-render.