### PR TITLE
Pin openblas exactly

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: c423a4511684554958dab55f2877df78e765b44f8eef46d5425891d6ac3b49bc
 
 build:
-  number: 200
+  number: 201
   # We lack openblas on Windows, and therefore can't build scipy there either currently.
   skip: true  # [win]
   features:
@@ -32,7 +32,7 @@ requirements:
     - python
     - blas 1.1 {{ variant }}
     - libgfortran
-    - openblas >=0.2.20
+    - openblas 0.2.20|0.2.20*
     - numpy >=1.9  # [not (win and py36)]
     - numpy >=1.11  # [win and py36]
 


### PR DESCRIPTION
abi-laboratory reports are misleading because they don't have lapack symbols listed.