### PR TITLE
[WIP] remove blas_openblas feature

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,10 +10,8 @@ source:
   sha256: 0291a2254d9a020af9b49ca648e8b41e1366be9a8a40849be9102626b2022422
 
 build:
-  number: 1202
+  number: 1203
   skip: true  # [win]
-  features:
-    - blas_{{ variant }}
 
 requirements:
   build:


### PR DESCRIPTION
it is being hotfixed out of the blas metapackage so we don't need it anymore (and indeed it *must* be removed to be installable), but we couldn't remove it until blas was hotfixed to remove track_features, which it is now

same as https://github.com/conda-forge/numpy-feedstock/pull/121