### PR TITLE
Statically link mingw runtime

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,12 +8,16 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_numpy1.17python3.7.____cpythonpython_implcpython:
-        CONFIG: linux_64_numpy1.17python3.7.____cpythonpython_implcpython
+      linux_64_numpy1.18python3.6.____cpythonpython_implcpython:
+        CONFIG: linux_64_numpy1.18python3.6.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
-      linux_64_numpy1.17python3.8.____cpythonpython_implcpython:
-        CONFIG: linux_64_numpy1.17python3.8.____cpythonpython_implcpython
+      linux_64_numpy1.18python3.7.____cpythonpython_implcpython:
+        CONFIG: linux_64_numpy1.18python3.7.____cpythonpython_implcpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+      linux_64_numpy1.18python3.8.____cpythonpython_implcpython:
+        CONFIG: linux_64_numpy1.18python3.8.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
       linux_64_numpy1.19python3.7.____73_pypypython_implpypy:

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,11 +8,14 @@ jobs:
     vmImage: macOS-10.15
   strategy:
     matrix:
-      osx_64_numpy1.17python3.7.____cpythonpython_implcpython:
-        CONFIG: osx_64_numpy1.17python3.7.____cpythonpython_implcpython
+      osx_64_numpy1.18python3.6.____cpythonpython_implcpython:
+        CONFIG: osx_64_numpy1.18python3.6.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
-      osx_64_numpy1.17python3.8.____cpythonpython_implcpython:
-        CONFIG: osx_64_numpy1.17python3.8.____cpythonpython_implcpython
+      osx_64_numpy1.18python3.7.____cpythonpython_implcpython:
+        CONFIG: osx_64_numpy1.18python3.7.____cpythonpython_implcpython
+        UPLOAD_PACKAGES: 'True'
+      osx_64_numpy1.18python3.8.____cpythonpython_implcpython:
+        CONFIG: osx_64_numpy1.18python3.8.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
       osx_64_numpy1.19python3.7.____73_pypypython_implpypy:
         CONFIG: osx_64_numpy1.19python3.7.____73_pypypython_implpypy

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -8,11 +8,14 @@ jobs:
     vmImage: vs2017-win2016
   strategy:
     matrix:
-      win_64_numpy1.17python3.7.____cpython:
-        CONFIG: win_64_numpy1.17python3.7.____cpython
+      win_64_numpy1.18python3.6.____cpython:
+        CONFIG: win_64_numpy1.18python3.6.____cpython
         UPLOAD_PACKAGES: 'True'
-      win_64_numpy1.17python3.8.____cpython:
-        CONFIG: win_64_numpy1.17python3.8.____cpython
+      win_64_numpy1.18python3.7.____cpython:
+        CONFIG: win_64_numpy1.18python3.7.____cpython
+        UPLOAD_PACKAGES: 'True'
+      win_64_numpy1.18python3.8.____cpython:
+        CONFIG: win_64_numpy1.18python3.8.____cpython
         UPLOAD_PACKAGES: 'True'
       win_64_numpy1.19python3.9.____cpython:
         CONFIG: win_64_numpy1.19python3.9.____cpython
@@ -92,7 +95,7 @@ jobs:
 
     - script: |
         call activate base
-        conda.exe build "recipe" -m .ci_support\%CONFIG%.yaml
+        conda.exe build "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables
       displayName: Build recipe
       env:
         PYTHONUNBUFFERED: 1

--- a/.ci_support/linux_64_numpy1.18python3.6.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_numpy1.18python3.6.____cpythonpython_implcpython.yaml
@@ -1,15 +1,11 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
 c_compiler:
 - gcc
 c_compiler_version:
 - '9'
-cdt_arch:
-- aarch64
 cdt_name:
-- cos7
+- cos6
 channel_sources:
-- conda-forge
+- conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
@@ -17,7 +13,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '9'
 docker_image:
-- quay.io/condaforge/linux-anvil-aarch64
+- quay.io/condaforge/linux-anvil-comp7
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -29,21 +25,23 @@ libcblas:
 liblapack:
 - 3.8 *netlib
 numpy:
-- '1.17'
+- '1.18'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.6.* *_cpython
 python_impl:
 - cpython
 target_platform:
-- linux-aarch64
+- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - fortran_compiler_version
+- - cdt_name
+  - docker_image
 - - python
   - numpy
   - python_impl

--- a/.ci_support/linux_64_numpy1.18python3.7.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_numpy1.18python3.7.____cpythonpython_implcpython.yaml
@@ -1,21 +1,31 @@
 c_compiler:
-- vs2017
+- gcc
+c_compiler_version:
+- '9'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- vs2017
+- gxx
+cxx_compiler_version:
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-comp7
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '9'
 libblas:
 - 3.8 *netlib
 libcblas:
 - 3.8 *netlib
 liblapack:
 - 3.8 *netlib
-m2w64_fortran_compiler:
-- m2w64-toolchain
 numpy:
-- '1.17'
+- '1.18'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -25,8 +35,13 @@ python:
 python_impl:
 - cpython
 target_platform:
-- win-64
+- linux-64
 zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - fortran_compiler_version
+- - cdt_name
+  - docker_image
 - - python
   - numpy
   - python_impl

--- a/.ci_support/linux_64_numpy1.18python3.8.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_numpy1.18python3.8.____cpythonpython_implcpython.yaml
@@ -1,0 +1,47 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '9'
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-comp7
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '9'
+libblas:
+- 3.8 *netlib
+libcblas:
+- 3.8 *netlib
+liblapack:
+- 3.8 *netlib
+numpy:
+- '1.18'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+python_impl:
+- cpython
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - fortran_compiler_version
+- - cdt_name
+  - docker_image
+- - python
+  - numpy
+  - python_impl

--- a/.ci_support/linux_aarch64_numpy1.18python3.6.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.18python3.6.____cpythonpython_implcpython.yaml
@@ -1,11 +1,15 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
 c_compiler:
 - gcc
 c_compiler_version:
 - '9'
+cdt_arch:
+- aarch64
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
@@ -13,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '9'
 docker_image:
-- quay.io/condaforge/linux-anvil-ppc64le
+- quay.io/condaforge/linux-anvil-aarch64
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -25,17 +29,17 @@ libcblas:
 liblapack:
 - 3.8 *netlib
 numpy:
-- '1.17'
+- '1.18'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.7.* *_cpython
+- 3.6.* *_cpython
 python_impl:
 - cpython
 target_platform:
-- linux-ppc64le
+- linux-aarch64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_aarch64_numpy1.18python3.7.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.18python3.7.____cpythonpython_implcpython.yaml
@@ -1,0 +1,49 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+c_compiler:
+- gcc
+c_compiler_version:
+- '9'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '9'
+libblas:
+- 3.8 *netlib
+libcblas:
+- 3.8 *netlib
+liblapack:
+- 3.8 *netlib
+numpy:
+- '1.18'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.7.* *_cpython
+python_impl:
+- cpython
+target_platform:
+- linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - fortran_compiler_version
+- - python
+  - numpy
+  - python_impl

--- a/.ci_support/linux_aarch64_numpy1.18python3.8.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.18python3.8.____cpythonpython_implcpython.yaml
@@ -1,0 +1,49 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+c_compiler:
+- gcc
+c_compiler_version:
+- '9'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '9'
+libblas:
+- 3.8 *netlib
+libcblas:
+- 3.8 *netlib
+liblapack:
+- 3.8 *netlib
+numpy:
+- '1.18'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+python_impl:
+- cpython
+target_platform:
+- linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - fortran_compiler_version
+- - python
+  - numpy
+  - python_impl

--- a/.ci_support/linux_ppc64le_numpy1.18python3.6.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.18python3.6.____cpythonpython_implcpython.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_compiler_version:
 - '9'
 cdt_name:
-- cos6
+- cos7
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -13,7 +13,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '9'
 docker_image:
-- quay.io/condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-ppc64le
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -25,23 +25,21 @@ libcblas:
 liblapack:
 - 3.8 *netlib
 numpy:
-- '1.17'
+- '1.18'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.7.* *_cpython
+- 3.6.* *_cpython
 python_impl:
 - cpython
 target_platform:
-- linux-64
+- linux-ppc64le
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - fortran_compiler_version
-- - cdt_name
-  - docker_image
 - - python
   - numpy
   - python_impl

--- a/.ci_support/linux_ppc64le_numpy1.18python3.7.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.18python3.7.____cpythonpython_implcpython.yaml
@@ -1,32 +1,45 @@
 c_compiler:
-- vs2017
+- gcc
+c_compiler_version:
+- '9'
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- vs2017
+- gxx
+cxx_compiler_version:
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-ppc64le
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '9'
 libblas:
 - 3.8 *netlib
 libcblas:
 - 3.8 *netlib
 liblapack:
 - 3.8 *netlib
-m2w64_fortran_compiler:
-- m2w64-toolchain
 numpy:
-- '1.17'
+- '1.18'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.7.* *_cpython
 python_impl:
 - cpython
 target_platform:
-- win-64
+- linux-ppc64le
 zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - fortran_compiler_version
 - - python
   - numpy
   - python_impl

--- a/.ci_support/linux_ppc64le_numpy1.18python3.8.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.18python3.8.____cpythonpython_implcpython.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_compiler_version:
 - '9'
 cdt_name:
-- cos6
+- cos7
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -13,7 +13,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '9'
 docker_image:
-- quay.io/condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-ppc64le
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -25,7 +25,7 @@ libcblas:
 liblapack:
 - 3.8 *netlib
 numpy:
-- '1.17'
+- '1.18'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -35,13 +35,11 @@ python:
 python_impl:
 - cpython
 target_platform:
-- linux-64
+- linux-ppc64le
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - fortran_compiler_version
-- - cdt_name
-  - docker_image
 - - python
   - numpy
   - python_impl

--- a/.ci_support/osx_64_numpy1.18python3.6.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_numpy1.18python3.6.____cpythonpython_implcpython.yaml
@@ -1,0 +1,45 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+c_compiler:
+- clang
+c_compiler_version:
+- '11'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '11'
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '9'
+libblas:
+- 3.8 *netlib
+libcblas:
+- 3.8 *netlib
+liblapack:
+- 3.8 *netlib
+macos_machine:
+- x86_64-apple-darwin13.4.0
+numpy:
+- '1.18'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.6.* *_cpython
+python_impl:
+- cpython
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - fortran_compiler_version
+- - python
+  - numpy
+  - python_impl

--- a/.ci_support/osx_64_numpy1.18python3.7.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_numpy1.18python3.7.____cpythonpython_implcpython.yaml
@@ -1,19 +1,17 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '9'
-cdt_name:
-- cos7
+- '11'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '9'
-docker_image:
-- quay.io/condaforge/linux-anvil-ppc64le
+- '11'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -24,18 +22,20 @@ libcblas:
 - 3.8 *netlib
 liblapack:
 - 3.8 *netlib
+macos_machine:
+- x86_64-apple-darwin13.4.0
 numpy:
-- '1.17'
+- '1.18'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.7.* *_cpython
 python_impl:
 - cpython
 target_platform:
-- linux-ppc64le
+- osx-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/osx_64_numpy1.18python3.8.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_numpy1.18python3.8.____cpythonpython_implcpython.yaml
@@ -1,23 +1,17 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '9'
-cdt_arch:
-- aarch64
-cdt_name:
-- cos7
+- '11'
 channel_sources:
-- conda-forge
+- conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '9'
-docker_image:
-- quay.io/condaforge/linux-anvil-aarch64
+- '11'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -28,18 +22,20 @@ libcblas:
 - 3.8 *netlib
 liblapack:
 - 3.8 *netlib
+macos_machine:
+- x86_64-apple-darwin13.4.0
 numpy:
-- '1.17'
+- '1.18'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.7.* *_cpython
+- 3.8.* *_cpython
 python_impl:
 - cpython
 target_platform:
-- linux-aarch64
+- osx-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/win_64_numpy1.18python3.6.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.18python3.6.____cpython.yaml
@@ -1,45 +1,32 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
 c_compiler:
-- clang
-c_compiler_version:
-- '11'
+- vs2017
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
-cxx_compiler_version:
-- '11'
-fortran_compiler:
-- gfortran
-fortran_compiler_version:
-- '9'
+- vs2017
 libblas:
 - 3.8 *netlib
 libcblas:
 - 3.8 *netlib
 liblapack:
 - 3.8 *netlib
-macos_machine:
-- x86_64-apple-darwin13.4.0
+m2w64_fortran_compiler:
+- m2w64-toolchain
 numpy:
-- '1.17'
+- '1.18'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.6.* *_cpython
 python_impl:
 - cpython
 target_platform:
-- osx-64
+- win-64
 zip_keys:
-- - c_compiler_version
-  - cxx_compiler_version
-  - fortran_compiler_version
 - - python
   - numpy
   - python_impl

--- a/.ci_support/win_64_numpy1.18python3.7.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.18python3.7.____cpython.yaml
@@ -1,31 +1,21 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
 c_compiler:
-- clang
-c_compiler_version:
-- '11'
+- vs2017
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
-cxx_compiler_version:
-- '11'
-fortran_compiler:
-- gfortran
-fortran_compiler_version:
-- '9'
+- vs2017
 libblas:
 - 3.8 *netlib
 libcblas:
 - 3.8 *netlib
 liblapack:
 - 3.8 *netlib
-macos_machine:
-- x86_64-apple-darwin13.4.0
+m2w64_fortran_compiler:
+- m2w64-toolchain
 numpy:
-- '1.17'
+- '1.18'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -35,11 +25,8 @@ python:
 python_impl:
 - cpython
 target_platform:
-- osx-64
+- win-64
 zip_keys:
-- - c_compiler_version
-  - cxx_compiler_version
-  - fortran_compiler_version
 - - python
   - numpy
   - python_impl

--- a/.ci_support/win_64_numpy1.18python3.8.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.18python3.8.____cpython.yaml
@@ -1,0 +1,32 @@
+c_compiler:
+- vs2017
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- vs2017
+libblas:
+- 3.8 *netlib
+libcblas:
+- 3.8 *netlib
+liblapack:
+- 3.8 *netlib
+m2w64_fortran_compiler:
+- m2w64-toolchain
+numpy:
+- '1.18'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+python_impl:
+- cpython
+target_platform:
+- win-64
+zip_keys:
+- - python
+  - numpy
+  - python_impl

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,6 @@
 ---
 kind: pipeline
-name: linux_aarch64_numpy1.17python3.7.___hcdfa3c3ca8
+name: linux_aarch64_numpy1.18python3.6.___h0f6feb4597
 
 platform:
   os: linux
@@ -10,7 +10,7 @@ steps:
 - name: Install and build
   image: quay.io/condaforge/linux-anvil-aarch64
   environment:
-    CONFIG: linux_aarch64_numpy1.17python3.7.____cpythonpython_implcpython
+    CONFIG: linux_aarch64_numpy1.18python3.6.____cpythonpython_implcpython
     UPLOAD_PACKAGES: True
     PLATFORM: linux-aarch64
     BINSTAR_TOKEN:
@@ -31,7 +31,7 @@ steps:
 
 ---
 kind: pipeline
-name: linux_aarch64_numpy1.17python3.8.___hbbdfb36bbd
+name: linux_aarch64_numpy1.18python3.7.___h1cadc65bfe
 
 platform:
   os: linux
@@ -41,7 +41,38 @@ steps:
 - name: Install and build
   image: quay.io/condaforge/linux-anvil-aarch64
   environment:
-    CONFIG: linux_aarch64_numpy1.17python3.8.____cpythonpython_implcpython
+    CONFIG: linux_aarch64_numpy1.18python3.7.____cpythonpython_implcpython
+    UPLOAD_PACKAGES: True
+    PLATFORM: linux-aarch64
+    BINSTAR_TOKEN:
+      from_secret: BINSTAR_TOKEN
+    FEEDSTOCK_TOKEN:
+      from_secret: FEEDSTOCK_TOKEN
+    STAGING_BINSTAR_TOKEN:
+      from_secret: STAGING_BINSTAR_TOKEN
+  commands:
+    - export FEEDSTOCK_ROOT="$DRONE_WORKSPACE"
+    - export RECIPE_ROOT="$FEEDSTOCK_ROOT/recipe"
+    - export CI=drone
+    - export GIT_BRANCH="$DRONE_BRANCH"
+    - export FEEDSTOCK_NAME=$(basename ${DRONE_REPO_NAME})
+    - sed -i '$ichown -R conda:conda "$FEEDSTOCK_ROOT"' /opt/docker/bin/entrypoint
+    - /opt/docker/bin/entrypoint $FEEDSTOCK_ROOT/.scripts/build_steps.sh
+    - echo "Done building"
+
+---
+kind: pipeline
+name: linux_aarch64_numpy1.18python3.8.___ha3ae6cc14c
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+- name: Install and build
+  image: quay.io/condaforge/linux-anvil-aarch64
+  environment:
+    CONFIG: linux_aarch64_numpy1.18python3.8.____cpythonpython_implcpython
     UPLOAD_PACKAGES: True
     PLATFORM: linux-aarch64
     BINSTAR_TOKEN:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,17 @@ language: generic
 
 matrix:
   include:
-    - env: CONFIG=linux_ppc64le_numpy1.17python3.7.____cpythonpython_implcpython UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
+    - env: CONFIG=linux_ppc64le_numpy1.18python3.6.____cpythonpython_implcpython UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
       os: linux
       arch: ppc64le
       dist: focal
 
-    - env: CONFIG=linux_ppc64le_numpy1.17python3.8.____cpythonpython_implcpython UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
+    - env: CONFIG=linux_ppc64le_numpy1.18python3.7.____cpythonpython_implcpython UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
+      os: linux
+      arch: ppc64le
+      dist: focal
+
+    - env: CONFIG=linux_ppc64le_numpy1.18python3.8.____cpythonpython_implcpython UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
       os: linux
       arch: ppc64le
       dist: focal

--- a/README.md
+++ b/README.md
@@ -49,17 +49,24 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_numpy1.17python3.7.____cpythonpython_implcpython</td>
+              <td>linux_64_numpy1.18python3.6.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1887&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/scipy-feedstock?branchName=master&jobName=linux&configuration=linux_64_numpy1.17python3.7.____cpythonpython_implcpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/scipy-feedstock?branchName=master&jobName=linux&configuration=linux_64_numpy1.18python3.6.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_numpy1.17python3.8.____cpythonpython_implcpython</td>
+              <td>linux_64_numpy1.18python3.7.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1887&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/scipy-feedstock?branchName=master&jobName=linux&configuration=linux_64_numpy1.17python3.8.____cpythonpython_implcpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/scipy-feedstock?branchName=master&jobName=linux&configuration=linux_64_numpy1.18python3.7.____cpythonpython_implcpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_numpy1.18python3.8.____cpythonpython_implcpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1887&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/scipy-feedstock?branchName=master&jobName=linux&configuration=linux_64_numpy1.18python3.8.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -77,17 +84,24 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_numpy1.17python3.7.____cpythonpython_implcpython</td>
+              <td>linux_aarch64_numpy1.18python3.6.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1887&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/scipy-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_numpy1.17python3.7.____cpythonpython_implcpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/scipy-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_numpy1.18python3.6.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_numpy1.17python3.8.____cpythonpython_implcpython</td>
+              <td>linux_aarch64_numpy1.18python3.7.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1887&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/scipy-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_numpy1.17python3.8.____cpythonpython_implcpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/scipy-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_numpy1.18python3.7.____cpythonpython_implcpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_numpy1.18python3.8.____cpythonpython_implcpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1887&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/scipy-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_numpy1.18python3.8.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -105,17 +119,24 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_numpy1.17python3.7.____cpythonpython_implcpython</td>
+              <td>linux_ppc64le_numpy1.18python3.6.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1887&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/scipy-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_numpy1.17python3.7.____cpythonpython_implcpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/scipy-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_numpy1.18python3.6.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_numpy1.17python3.8.____cpythonpython_implcpython</td>
+              <td>linux_ppc64le_numpy1.18python3.7.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1887&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/scipy-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_numpy1.17python3.8.____cpythonpython_implcpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/scipy-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_numpy1.18python3.7.____cpythonpython_implcpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_numpy1.18python3.8.____cpythonpython_implcpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1887&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/scipy-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_numpy1.18python3.8.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -133,17 +154,24 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_numpy1.17python3.7.____cpythonpython_implcpython</td>
+              <td>osx_64_numpy1.18python3.6.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1887&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/scipy-feedstock?branchName=master&jobName=osx&configuration=osx_64_numpy1.17python3.7.____cpythonpython_implcpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/scipy-feedstock?branchName=master&jobName=osx&configuration=osx_64_numpy1.18python3.6.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_numpy1.17python3.8.____cpythonpython_implcpython</td>
+              <td>osx_64_numpy1.18python3.7.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1887&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/scipy-feedstock?branchName=master&jobName=osx&configuration=osx_64_numpy1.17python3.8.____cpythonpython_implcpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/scipy-feedstock?branchName=master&jobName=osx&configuration=osx_64_numpy1.18python3.7.____cpythonpython_implcpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_numpy1.18python3.8.____cpythonpython_implcpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1887&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/scipy-feedstock?branchName=master&jobName=osx&configuration=osx_64_numpy1.18python3.8.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -175,17 +203,24 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_numpy1.17python3.7.____cpython</td>
+              <td>win_64_numpy1.18python3.6.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1887&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/scipy-feedstock?branchName=master&jobName=win&configuration=win_64_numpy1.17python3.7.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/scipy-feedstock?branchName=master&jobName=win&configuration=win_64_numpy1.18python3.6.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_numpy1.17python3.8.____cpython</td>
+              <td>win_64_numpy1.18python3.7.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1887&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/scipy-feedstock?branchName=master&jobName=win&configuration=win_64_numpy1.17python3.8.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/scipy-feedstock?branchName=master&jobName=win&configuration=win_64_numpy1.18python3.7.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_numpy1.18python3.8.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1887&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/scipy-feedstock?branchName=master&jobName=win&configuration=win_64_numpy1.18python3.8.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -43,6 +43,9 @@ set "LDFLAGS="
 REM don't add d1trimfile option because clang doesn't recognize it.
 set "SRC_DIR="
 
+REM static runtime
+set "LDFLAGS=-static-libgfortran -static-libgcc"
+
 %PYTHON% -m pip install . -vv
 if %ERRORLEVEL% neq 0 exit 1
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,8 +28,7 @@ source:
     folder: scipy/_lib/boost                                                            # [not (aarch64 or ppc64le)]
 
 build:
-  number: 1
-  skip: true  # [py2k or py<=36]
+  number: 2
 
 requirements:
   build:


### PR DESCRIPTION
Statically link mingw libgfortran & libgcc to avoid conflict with other toolchain versions (currently it conflicts with the openturns package) since 1.5.3, may be related to #146