### PR TITLE
remove redundant version guard

### DIFF
--- a/.ci_support/osx_arm64_python3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.8.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler:
 c_compiler_version:
 - '11'
 channel_sources:
-- conda-forge/label/rust_dev,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:

--- a/.ci_support/osx_arm64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.9.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler:
 c_compiler_version:
 - '11'
 channel_sources:
-- conda-forge/label/rust_dev,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @beckermr @jakirkham @msarahan @ocefpaf @rgommers
+* @jakirkham @msarahan @ocefpaf @rgommers

--- a/README.md
+++ b/README.md
@@ -267,7 +267,6 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
-* [@beckermr](https://github.com/beckermr/)
 * [@jakirkham](https://github.com/jakirkham/)
 * [@msarahan](https://github.com/msarahan/)
 * [@ocefpaf](https://github.com/ocefpaf/)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,4 @@
 {% set version = "1.6.0" %}
-{% set ver_major_minor = ".".join(version.split(".")[:2]) %}
 
 package:
   name: scipy
@@ -46,9 +45,6 @@ test:
     - pytest
     - pytest-xdist
     - mpmath
-{% if ver_major_minor == "1.5" %}
-    - blas * netlib  # [ppc64le]
-{% endif %}
 
 about:
   home: http://www.scipy.org/


### PR DESCRIPTION
This has become obvious because the CI for #151 passed. Incidentally, also helpful because one of the aarch-builds timed out on master.