### PR TITLE
POC: Build windows with vs2019

### DIFF
--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -5,7 +5,7 @@
 jobs:
 - job: win
   pool:
-    vmImage: vs2017-win2016
+    vmImage: windows-2019
   strategy:
     matrix:
       win_64_numpy1.17python3.7.____cpython:

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -4,5 +4,7 @@ provider: {linux_aarch64: default, linux_ppc64le: default}
 test_on_native_only: true
 azure:
   settings_win:
+    pool:
+      vmImage: windows-2019
     variables:
       CONDA_BLD_PATH: "C:\\\\bld\\\\"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: adfc9a8457ea16c08acd2cd1e54f4826ca8e7345060d1cc4c879b6f26c400c66
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py2k or py<=36]
 
 requirements:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

In https://github.com/scipy/scipy/pull/13713, the discussion came up of using the universal C runtime (since vs2015) to uncouple the compiler version that scipy uses for windows from the one used to build CPython itself.

@rgommers is wary of doing this without knowing what subtle bugs this will incur, and one option that came up was demonstrating this in conda-forge. AFAICT, conda-forge _already_ relies on the UCRT (cf. https://github.com/conda-forge/vc-feedstock/blob/master/recipe/meta.yaml), because some packages are selectively being built with vs2019 already, while CPython obviously isn't.

This PR is to demonstrate just that; IMO it could be merged, but that might a bit more discussion. I'll also open a PR for the scipy CI itself.