### PR TITLE
reduce test modules on aarch again

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -71,10 +71,11 @@ test:
     # show SIMD features (some failures occur depending on presence/absence of e.g. AVX512)
     # change to np.show_config() for v>=1.22.0, cf. numpy/numpy#19130
     - python -c "import numpy; numpy._pytesttester._show_numpy_info()"
-    # Run only fast tests on drone as it times out; otherwise set label='full' (note default: label='fast')
+    # Run only fast tests for key modules on drone as it times out; otherwise set label='full' (note default: label='fast')
     {% set label = "'fast'" if aarch64 else "'full'" %}
+    {% set tests = "['scipy.linalg', 'scipy.fft']" if aarch64 else "None" %}
     # for signature, see https://github.com/scipy/scipy/blob/v1.7.0/scipy/_lib/_testutils.py#L27
-    - python -c "import scipy; scipy.test(verbose=2, label={{ label }}, extra_argv=['--durations=50'])"
+    - python -c "import scipy; scipy.test(verbose=2, label={{ label }}, tests={{ tests }}, extra_argv=['--durations=50'])"
   imports:
     - scipy
     - scipy.cluster._hierarchy


### PR DESCRIPTION
Trying to get aarch to stop timing out again.