### PR TITLE
re-enable testing for PPC in emulation

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -117,9 +117,7 @@ test:
     # https://github.com/scipy/scipy/blob/v1.7.0/scipy/_lib/_testutils.py#L27
     {% set param = "verbose=1, label=" + label + ", tests=None" %}
     {% set extra = "extra_argv=['-k', 'not (" + tests_to_skip + ")', '-nauto', '--timeout=1200', '--durations=50']" %}
-    - python -c "import scipy, sys; sys.exit(not scipy.test({{ param }}, {{ extra }}))"  # [not ppc64le]
-    # NOTE: test suite is skipped on ppc due to bugs in QEMU code that cause
-    # CI to fail, even though the tests would run through on native hardware
+    - python -c "import scipy, sys; sys.exit(not scipy.test({{ param }}, {{ extra }}))"
   imports:
     - scipy
     # reference for public API is effectively

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -72,12 +72,8 @@ requirements:
 {% set tests_to_skip = "_not_a_real_test" %}
 # skip a test that fails with MKL + AVX512 (non-AVX512 passes), scipy/scipy#15533
 {% set tests_to_skip = tests_to_skip + " or test_x0_equals_Mb[bicgstab]" %}
-# scipy/scipy#16926
-{% set tests_to_skip = tests_to_skip + " or test_solve_discrete_are" %}         # [linux]
 # scipy/scipy#16927
 {% set tests_to_skip = tests_to_skip + " or test_failure_to_run_iterations" %}  # [linux]
-# accuracy failure with AVX512
-{% set tests_to_skip = tests_to_skip + " or (TestTruncnorm and test_moments)" %}
 # these multithreading tests occasionally hang in emulation
 {% set tests_to_skip = tests_to_skip + " or test_immediate_updating" %}         # [aarch64 or ppc64le]
 {% set tests_to_skip = tests_to_skip + " or test_mixed_threads_processes" %}    # [aarch64 or ppc64le]
@@ -89,10 +85,6 @@ requirements:
 {% set tests_to_skip = tests_to_skip + " or (test_optimize and TestBrute and test_workers)" %}    # [aarch64 or ppc64le]
 # tests that run into timeouts (set in scipy test suite) in emulation
 {% set tests_to_skip = tests_to_skip + " or (test_propack and test_examples)" %}                  # [aarch64 or ppc64le]
-# needs one or two gc.collect()
-{% set tests_to_skip = tests_to_skip + " or test_cdist_refcount" %}             # [python_impl == "pypy"]
-# unclear why a warning isn't raised. Might be related to scipy/scipy#15121
-{% set tests_to_skip = tests_to_skip + " or test_boost_eval_issue_14606" %}     # [python_impl == "pypy"]
 # very slow tests for pypy in emulation
 {% set tests_to_skip = tests_to_skip + " or test_cont_basic[500" %}                   # [(python_impl == "pypy") and (aarch64 or ppc64le)]
 {% set tests_to_skip = tests_to_skip + " or TestDifferentialEvolutionSolver" %}       # [(python_impl == "pypy") and (aarch64 or ppc64le)]


### PR DESCRIPTION
Spurred by the success of https://github.com/conda-forge/numpy-feedstock/pull/274, let's try for scipy as well