### PR TITLE
also enable recent patches on windows

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,13 +20,13 @@ source:
       # backport https://github.com/scipy/scipy/pull/18034
       - patches/0002-BLD-avoid-running-run_command-py3-.-for-better-cross.patch
       # backport https://github.com/scipy/scipy/pull/18263
-      - patches/0003-BUG-some-tweaks-to-PROPACK-f2py-wrapper-and-build-fl.patch  # [not win]
+      - patches/0003-BUG-some-tweaks-to-PROPACK-f2py-wrapper-and-build-fl.patch
       # backport https://github.com/scipy/scipy/pull/18264 (3 commits)
-      - patches/0004-MAINT-remove-from-numpy.math-cimport-usages.patch           # [not win]
-      - patches/0005-MAINT-sync-changes-to-npy_blas.h-and-npy_blas_base.h.patch  # [not win]
-      - patches/0006-BUG-include-npy_common.h-in-npy_cblas.h.patch               # [not win]
+      - patches/0004-MAINT-remove-from-numpy.math-cimport-usages.patch
+      - patches/0005-MAINT-sync-changes-to-npy_blas.h-and-npy_blas_base.h.patch
+      - patches/0006-BUG-include-npy_common.h-in-npy_cblas.h.patch
       # backport https://github.com/scipy/scipy/pull/18426
-      - patches/0007-BLD-fix-two-regressions-for-Duse-g77-abi.patch              # [not win]
+      - patches/0007-BLD-fix-two-regressions-for-Duse-g77-abi.patch
   # https://github.com/scipy/scipy/tree/v{{ version }}/scipy/_lib
   - git_url: https://github.com/scipy/boost-headers-only.git
     git_rev: 3af99e6d566043072e95bc882d32c9c26f37e0ba
@@ -43,7 +43,7 @@ source:
     folder: scipy/sparse/linalg/_propack/PROPACK
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,8 +25,10 @@ source:
       - patches/0004-MAINT-remove-from-numpy.math-cimport-usages.patch
       - patches/0005-MAINT-sync-changes-to-npy_blas.h-and-npy_blas_base.h.patch
       - patches/0006-BUG-include-npy_common.h-in-npy_cblas.h.patch
-      # backport https://github.com/scipy/scipy/pull/18426
+      # backport https://github.com/scipy/scipy/pull/18426 (3 commits)
       - patches/0007-BLD-fix-two-regressions-for-Duse-g77-abi.patch
+      - patches/0008-BLD-add-numpy-and-python-include-dirs-to-propack-sta.patch
+      - patches/0009-BLD-fix-yet-another-PROPACK-build-issue.patch
   # https://github.com/scipy/scipy/tree/v{{ version }}/scipy/_lib
   - git_url: https://github.com/scipy/boost-headers-only.git
     git_rev: 3af99e6d566043072e95bc882d32c9c26f37e0ba

--- a/recipe/patches/0001-BLD-use-a-relative-path-to-numpy-pybind11-pythran-in.patch
+++ b/recipe/patches/0001-BLD-use-a-relative-path-to-numpy-pybind11-pythran-in.patch
@@ -1,7 +1,7 @@
 From 66ccdf8520ec803cfd00371833170008f3b0f666 Mon Sep 17 00:00:00 2001
 From: Ralf Gommers <ralf.gommers@gmail.com>
 Date: Sun, 19 Feb 2023 22:13:39 +0000
-Subject: [PATCH 1/7] BLD: use a relative path to numpy/pybind11/pythran
+Subject: [PATCH 1/9] BLD: use a relative path to numpy/pybind11/pythran
  include and lib dirs
 
 This should make things work with in-tree virtual envs, as well as some

--- a/recipe/patches/0002-BLD-avoid-running-run_command-py3-.-for-better-cross.patch
+++ b/recipe/patches/0002-BLD-avoid-running-run_command-py3-.-for-better-cross.patch
@@ -1,7 +1,7 @@
 From 60c26eccbd97de83d0cba143146365527667d0f8 Mon Sep 17 00:00:00 2001
 From: Ralf Gommers <ralf.gommers@gmail.com>
 Date: Thu, 23 Feb 2023 14:43:52 +0000
-Subject: [PATCH 2/7] BLD: avoid running `run_command(py3, ...)`, for better
+Subject: [PATCH 2/9] BLD: avoid running `run_command(py3, ...)`, for better
  cross-compiling
 
 Adding the ability to specify the paths to the numpy, pybind11 and

--- a/recipe/patches/0003-BUG-some-tweaks-to-PROPACK-f2py-wrapper-and-build-fl.patch
+++ b/recipe/patches/0003-BUG-some-tweaks-to-PROPACK-f2py-wrapper-and-build-fl.patch
@@ -1,7 +1,7 @@
 From c1ed688ccb326fe8b95a33d55f8c4a3851343236 Mon Sep 17 00:00:00 2001
 From: Ralf Gommers <ralf.gommers@gmail.com>
 Date: Sat, 8 Apr 2023 20:11:36 +0100
-Subject: [PATCH 3/7] BUG: some tweaks to PROPACK f2py wrapper and build flags
+Subject: [PATCH 3/9] BUG: some tweaks to PROPACK f2py wrapper and build flags
 
 Still far from fixed, but it should be closer - and prepares
 for removal of `setup.py` and re-introduction of Accelerate.

--- a/recipe/patches/0004-MAINT-remove-from-numpy.math-cimport-usages.patch
+++ b/recipe/patches/0004-MAINT-remove-from-numpy.math-cimport-usages.patch
@@ -1,7 +1,7 @@
 From ad526ed010333ffcac566a5a6bc43589fd389e82 Mon Sep 17 00:00:00 2001
 From: Ralf Gommers <ralf.gommers@gmail.com>
 Date: Sat, 8 Apr 2023 22:45:37 +0100
-Subject: [PATCH 4/7] MAINT: remove `from numpy.math cimport` usages
+Subject: [PATCH 4/9] MAINT: remove `from numpy.math cimport` usages
 
 We'd like to get rid of `libnpymath`, and the (unrelated)
 `numpy.math` in the Python API was also just deprecated.

--- a/recipe/patches/0005-MAINT-sync-changes-to-npy_blas.h-and-npy_blas_base.h.patch
+++ b/recipe/patches/0005-MAINT-sync-changes-to-npy_blas.h-and-npy_blas_base.h.patch
@@ -1,7 +1,7 @@
 From e16518a0a04db6b04be7550d2d243d76969edd6d Mon Sep 17 00:00:00 2001
 From: Ralf Gommers <ralf.gommers@gmail.com>
 Date: Sun, 9 Apr 2023 12:46:04 +0100
-Subject: [PATCH 5/7] MAINT: sync changes to `npy_blas.h` and `npy_blas_base.h`
+Subject: [PATCH 5/9] MAINT: sync changes to `npy_blas.h` and `npy_blas_base.h`
  from numpy
 
 ---

--- a/recipe/patches/0006-BUG-include-npy_common.h-in-npy_cblas.h.patch
+++ b/recipe/patches/0006-BUG-include-npy_common.h-in-npy_cblas.h.patch
@@ -1,7 +1,7 @@
 From 578b57b0f40da9d4aa07f21445aa9e19d00a4f77 Mon Sep 17 00:00:00 2001
 From: Ralf Gommers <ralf.gommers@gmail.com>
 Date: Sun, 9 Apr 2023 13:00:51 +0100
-Subject: [PATCH 6/7] BUG: include `npy_common.h` in `npy_cblas.h`
+Subject: [PATCH 6/9] BUG: include `npy_common.h` in `npy_cblas.h`
 
 This is necessary, because it uses `npy_int64` & co. The implicit
 assumption previously was that this was made available in the

--- a/recipe/patches/0007-BLD-fix-two-regressions-for-Duse-g77-abi.patch
+++ b/recipe/patches/0007-BLD-fix-two-regressions-for-Duse-g77-abi.patch
@@ -1,7 +1,7 @@
 From 36b3d3c49103b1ca57234fd399edda5fcc942d10 Mon Sep 17 00:00:00 2001
 From: Ralf Gommers <ralf.gommers@gmail.com>
 Date: Fri, 5 May 2023 08:49:59 +0200
-Subject: [PATCH 7/7] BLD: fix two regressions for `-Duse-g77-abi`
+Subject: [PATCH 7/9] BLD: fix two regressions for `-Duse-g77-abi`
 
 The first was caused by gh-18264 and caused a build issue,
 the second was a missing CBLAS issue when building against Netlib BLAS

--- a/recipe/patches/0008-BLD-add-numpy-and-python-include-dirs-to-propack-sta.patch
+++ b/recipe/patches/0008-BLD-add-numpy-and-python-include-dirs-to-propack-sta.patch
@@ -1,0 +1,41 @@
+From 11287e071393500812ef2f9a3c0729605d96a967 Mon Sep 17 00:00:00 2001
+From: Ralf Gommers <ralf.gommers@gmail.com>
+Date: Mon, 8 May 2023 17:13:58 +0200
+Subject: [PATCH 8/9] BLD: add numpy and python include dirs to propack static
+ library
+
+This is needed when building with the g77 ABI wrappers, because
+`npy_common.h` is used within them (for the `npy_int64` symbol).
+It looks like removing that symbol and replacing it with `int64_t`
+isn't completely straightforward; those two symbols are not
+compatible.
+
+[skip circle] [skip cirrus]
+---
+ scipy/sparse/linalg/_propack/setup.py | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/scipy/sparse/linalg/_propack/setup.py b/scipy/sparse/linalg/_propack/setup.py
+index 94a4f055b..fdc67fd34 100644
+--- a/scipy/sparse/linalg/_propack/setup.py
++++ b/scipy/sparse/linalg/_propack/setup.py
+@@ -1,4 +1,5 @@
+ import pathlib
++from distutils.sysconfig import get_python_inc
+ 
+ import numpy as np
+ 
+@@ -65,7 +66,12 @@ def configuration(parent_package='', top_path=None):
+         config.add_library(propack_lib,
+                            sources=src,
+                            macros=cmacros,
+-                           include_dirs=src_dir,
++                           include_dirs=[
++                               src_dir,
++                               # because npy_common.h is used in g77 abi wrappers
++                               get_python_inc(),
++                               np.get_include(),
++                           ],
+                            depends=['setup.py'])
+         ext = config.add_extension(f'_{prefix}propack',
+                                    sources=f'{prefix}propack.pyf',

--- a/recipe/patches/0009-BLD-fix-yet-another-PROPACK-build-issue.patch
+++ b/recipe/patches/0009-BLD-fix-yet-another-PROPACK-build-issue.patch
@@ -1,0 +1,46 @@
+From bec1ee39a6e930fdc25ab6925889d7b74345620d Mon Sep 17 00:00:00 2001
+From: Ralf Gommers <ralf.gommers@gmail.com>
+Date: Tue, 9 May 2023 21:55:27 +0200
+Subject: [PATCH 9/9] BLD: fix yet another PROPACK build issue
+
+The `setup.py` code is written kinda strangely, but checking the
+build logs it is clear that the only OpenMP related flag is used
+is `-U_OPENMP`, which undefines `_OPENMP` and hence the OpenMP
+code in PROPACK is not used.
+
+The define in the meson.build file was incorrectly done for C rather
+than Fortran.
+
+[skip cirrus] [skip circle]
+---
+ scipy/sparse/linalg/_propack/meson.build | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/scipy/sparse/linalg/_propack/meson.build b/scipy/sparse/linalg/_propack/meson.build
+index b201691a6..abdf14914 100644
+--- a/scipy/sparse/linalg/_propack/meson.build
++++ b/scipy/sparse/linalg/_propack/meson.build
+@@ -85,11 +85,11 @@ elements = [
+   ['_zpropack', z_src, 'zpropack.pyf']
+ ]
+ 
+-cargs_propack = ['-D_OPENMP']  # FIXME: _OPENMP is needed now, but not good!
++fargs_propack = ['-U_OPENMP']
+ if use_g77_abi
+   # This define needs to be removed from PROPACK code, in favor of using
+   # `wcdotc` unconditionally, like is done in ARPACK.
+-  cargs_propack += ['-DSCIPY_USE_G77_CDOTC_WRAP=1']
++  fargs_propack += ['-DSCIPY_USE_G77_CDOTC_WRAP=1']
+ endif
+ foreach ele: elements
+   # PROPACK integration is pretty much broken, see for example gh-15108.
+@@ -97,8 +97,8 @@ foreach ele: elements
+   # architectures (stated reason: "it blows up").
+   propack_lib = static_library('lib_' + ele[0],
+     ele[1],
+-    c_args: cargs_propack,
+     fortran_args: [
++      fargs_propack,
+       fortran_ignore_warnings, 
+       _fflag_Wno_intrinsic_shadow,
+       _fflag_Wno_uninitialized,


### PR DESCRIPTION
Excluded from #233 to make forward progress, I realised we should ensure these patches work on windows, so that 1.11 remains buildable with distutils.