### PR TITLE
Ensure we don't package redundant fortran artefacts in scipy-tests

### DIFF
--- a/recipe/build-output.bat
+++ b/recipe/build-output.bat
@@ -108,4 +108,11 @@ if "%PKG_NAME%"=="scipy" (
     REM return code 1 means success, for anything else show log (though we'll know
     REM anyway, because if the copy fails, compilation for `scipy-tests` will break).
     (robocopy backup base /E /MOVE >copylog) || if !ERRORLEVEL! neq 1 type copylog
+) else (
+    REM the artefacts built by gfortran on windows contain a hash (for example
+    REM liblapack.5QFP43TP7SQZWGC7PX3VWUMNJLCPJGN3.gfortran-win_amd64.dll), and This
+    REM hash will change between the two times we build scipy here. Even though conda
+    REM doesn't like it to delete DSOs from other outputs, delete all of
+    REM %SP_DIR%\scipy\.libs here to ensure we don't pick up any redundant fortran libs.
+    rmdir /s /q %SP_DIR%\scipy\.libs
 )

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,7 +47,7 @@ source:
     folder: base/scipy/sparse/linalg/_propack/PROPACK
 
 build:
-  number: 3
+  number: 4
 
 requirements:
   build:


### PR DESCRIPTION
For some insane reason, random bits get deleted with the otherwise very targeted deletions from #184 (and no offending deletion shows up in the logs either...)

Fixes #236

As I asked on element - if someone has a solution for testing this that doesn't involve (publishing) an extra output, I'm all ears!