### PR TITLE
meson on windows with clang-cl & flang; python 3.12 support

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -24,12 +24,12 @@ jobs:
         CONFIG: linux_64_numpy1.23python3.11.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_aarch64_numpy1.22python3.10.____cpythonpython_implcpython:
-        CONFIG: linux_aarch64_numpy1.22python3.10.____cpythonpython_implcpython
+      linux_64_numpy1.26python3.12.____cpythonpython_implcpython:
+        CONFIG: linux_64_numpy1.26python3.12.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_aarch64_numpy1.22python3.9.____73_pypypython_implpypy:
-        CONFIG: linux_aarch64_numpy1.22python3.9.____73_pypypython_implpypy
+      linux_aarch64_numpy1.22python3.10.____cpythonpython_implcpython:
+        CONFIG: linux_aarch64_numpy1.22python3.10.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_aarch64_numpy1.22python3.9.____cpythonpython_implcpython:
@@ -40,12 +40,12 @@ jobs:
         CONFIG: linux_aarch64_numpy1.23python3.11.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_ppc64le_numpy1.22python3.10.____cpythonpython_implcpython:
-        CONFIG: linux_ppc64le_numpy1.22python3.10.____cpythonpython_implcpython
+      linux_aarch64_numpy1.26python3.12.____cpythonpython_implcpython:
+        CONFIG: linux_aarch64_numpy1.26python3.12.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_ppc64le_numpy1.22python3.9.____73_pypypython_implpypy:
-        CONFIG: linux_ppc64le_numpy1.22python3.9.____73_pypypython_implpypy
+      linux_ppc64le_numpy1.22python3.10.____cpythonpython_implcpython:
+        CONFIG: linux_ppc64le_numpy1.22python3.10.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_ppc64le_numpy1.22python3.9.____cpythonpython_implcpython:
@@ -54,6 +54,10 @@ jobs:
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_ppc64le_numpy1.23python3.11.____cpythonpython_implcpython:
         CONFIG: linux_ppc64le_numpy1.23python3.11.____cpythonpython_implcpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_ppc64le_numpy1.26python3.12.____cpythonpython_implcpython:
+        CONFIG: linux_ppc64le_numpy1.26python3.12.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
   timeoutInMinutes: 360

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -20,6 +20,9 @@ jobs:
       osx_64_numpy1.23python3.11.____cpythonpython_implcpython:
         CONFIG: osx_64_numpy1.23python3.11.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
+      osx_64_numpy1.26python3.12.____cpythonpython_implcpython:
+        CONFIG: osx_64_numpy1.26python3.12.____cpythonpython_implcpython
+        UPLOAD_PACKAGES: 'True'
       osx_arm64_numpy1.22python3.10.____cpython:
         CONFIG: osx_arm64_numpy1.22python3.10.____cpython
         UPLOAD_PACKAGES: 'True'
@@ -28,6 +31,9 @@ jobs:
         UPLOAD_PACKAGES: 'True'
       osx_arm64_numpy1.23python3.11.____cpython:
         CONFIG: osx_arm64_numpy1.23python3.11.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_numpy1.26python3.12.____cpython:
+        CONFIG: osx_arm64_numpy1.26python3.12.____cpython
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
 

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -20,6 +20,9 @@ jobs:
       win_64_numpy1.23python3.11.____cpythonpython_implcpython:
         CONFIG: win_64_numpy1.23python3.11.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
+      win_64_numpy1.26python3.12.____cpythonpython_implcpython:
+        CONFIG: win_64_numpy1.26python3.12.____cpythonpython_implcpython
+        UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
   variables:
     CONDA_BLD_PATH: C:\\bld\\

--- a/.ci_support/linux_64_numpy1.26python3.12.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_numpy1.26python3.12.____cpythonpython_implcpython.yaml
@@ -1,13 +1,9 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
 c_compiler:
 - gcc
 c_compiler_version:
 - '12'
-cdt_arch:
-- aarch64
 cdt_name:
-- cos7
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
@@ -29,17 +25,17 @@ libcblas:
 liblapack:
 - 3.9 *netlib
 numpy:
-- '1.22'
+- '1.26'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_73_pypy
+- 3.12.* *_cpython
 python_impl:
-- pypy
+- cpython
 target_platform:
-- linux-aarch64
+- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_aarch64_numpy1.26python3.12.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.26python3.12.____cpythonpython_implcpython.yaml
@@ -1,0 +1,49 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+c_compiler:
+- gcc
+c_compiler_version:
+- '12'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '12'
+libblas:
+- 3.9 *netlib
+libcblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
+numpy:
+- '1.26'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+python_impl:
+- cpython
+target_platform:
+- linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - fortran_compiler_version
+- - python
+  - numpy
+  - python_impl

--- a/.ci_support/linux_ppc64le_numpy1.26python3.12.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.26python3.12.____cpythonpython_implcpython.yaml
@@ -1,0 +1,45 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '12'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '12'
+libblas:
+- 3.9 *netlib
+libcblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
+numpy:
+- '1.26'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+python_impl:
+- cpython
+target_platform:
+- linux-ppc64le
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - fortran_compiler_version
+- - python
+  - numpy
+  - python_impl

--- a/.ci_support/migrations/python312.yaml
+++ b/.ci_support/migrations/python312.yaml
@@ -1,0 +1,42 @@
+migrator_ts: 1695046563
+__migrator:
+    migration_number: 1
+    operation: key_add
+    primary_key: python
+    ordering:
+        python:
+            - 3.6.* *_cpython
+            - 3.7.* *_cpython
+            - 3.8.* *_cpython
+            - 3.9.* *_cpython
+            - 3.10.* *_cpython
+            - 3.11.* *_cpython
+            - 3.12.* *_cpython  # new entry
+            - 3.6.* *_73_pypy
+            - 3.7.* *_73_pypy
+            - 3.8.* *_73_pypy
+            - 3.9.* *_73_pypy
+    paused: false
+    longterm: True
+    pr_limit: 60
+    max_solver_attempts: 5  # this will make the bot retry "not solvable" stuff 5 times
+    exclude:
+      # this shouldn't attempt to modify the python feedstocks
+      - python
+      - pypy3.6
+      - pypy-meta
+      - cross-python
+      - python_abi
+    exclude_pinned_pkgs: false
+    additional_zip_keys:
+      - channel_sources
+
+python:
+  - 3.12.* *_cpython
+channel_sources:
+  - conda-forge/label/python_rc,conda-forge
+# additional entries to add for zip_keys
+numpy:
+  - 1.26
+python_impl:
+  - cpython

--- a/.ci_support/osx_64_numpy1.26python3.12.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_numpy1.26python3.12.____cpythonpython_implcpython.yaml
@@ -1,19 +1,17 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '12'
-cdt_name:
-- cos7
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '12'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- '15'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -24,18 +22,20 @@ libcblas:
 - 3.9 *netlib
 liblapack:
 - 3.9 *netlib
+macos_machine:
+- x86_64-apple-darwin13.4.0
 numpy:
-- '1.22'
+- '1.26'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_73_pypy
+- 3.12.* *_cpython
 python_impl:
-- pypy
+- cpython
 target_platform:
-- linux-ppc64le
+- osx-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/osx_arm64_numpy1.26python3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.26python3.12.____cpython.yaml
@@ -1,0 +1,45 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '15'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '15'
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '12'
+libblas:
+- 3.9 *netlib
+libcblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
+macos_machine:
+- arm64-apple-darwin20.0.0
+numpy:
+- '1.26'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+python_impl:
+- cpython
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - fortran_compiler_version
+- - python
+  - numpy
+  - python_impl

--- a/.ci_support/win_64_numpy1.22python3.10.____cpythonpython_implcpython.yaml
+++ b/.ci_support/win_64_numpy1.22python3.10.____cpythonpython_implcpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - vs2019
 channel_sources:
-- conda-forge
+- conda-forge/label/llvm_rc,conda-forge/label/meson_dev,conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
@@ -12,8 +12,6 @@ libcblas:
 - 3.9 *netlib
 liblapack:
 - 3.9 *netlib
-m2w64_fortran_compiler:
-- m2w64-toolchain
 numpy:
 - '1.22'
 pin_run_as_build:

--- a/.ci_support/win_64_numpy1.22python3.9.____73_pypypython_implpypy.yaml
+++ b/.ci_support/win_64_numpy1.22python3.9.____73_pypypython_implpypy.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - vs2019
 channel_sources:
-- conda-forge
+- conda-forge/label/llvm_rc,conda-forge/label/meson_dev,conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
@@ -12,8 +12,6 @@ libcblas:
 - 3.9 *netlib
 liblapack:
 - 3.9 *netlib
-m2w64_fortran_compiler:
-- m2w64-toolchain
 numpy:
 - '1.22'
 pin_run_as_build:

--- a/.ci_support/win_64_numpy1.22python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/win_64_numpy1.22python3.9.____cpythonpython_implcpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - vs2019
 channel_sources:
-- conda-forge
+- conda-forge/label/llvm_rc,conda-forge/label/meson_dev,conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
@@ -12,8 +12,6 @@ libcblas:
 - 3.9 *netlib
 liblapack:
 - 3.9 *netlib
-m2w64_fortran_compiler:
-- m2w64-toolchain
 numpy:
 - '1.22'
 pin_run_as_build:

--- a/.ci_support/win_64_numpy1.23python3.11.____cpythonpython_implcpython.yaml
+++ b/.ci_support/win_64_numpy1.23python3.11.____cpythonpython_implcpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - vs2019
 channel_sources:
-- conda-forge
+- conda-forge/label/llvm_rc,conda-forge/label/meson_dev,conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
@@ -12,8 +12,6 @@ libcblas:
 - 3.9 *netlib
 liblapack:
 - 3.9 *netlib
-m2w64_fortran_compiler:
-- m2w64-toolchain
 numpy:
 - '1.23'
 pin_run_as_build:

--- a/.ci_support/win_64_numpy1.26python3.12.____cpythonpython_implcpython.yaml
+++ b/.ci_support/win_64_numpy1.26python3.12.____cpythonpython_implcpython.yaml
@@ -1,0 +1,30 @@
+c_compiler:
+- vs2019
+channel_sources:
+- conda-forge/label/llvm_rc,conda-forge/label/meson_dev,conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- vs2019
+libblas:
+- 3.9 *netlib
+libcblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
+numpy:
+- '1.26'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+python_impl:
+- cpython
+target_platform:
+- win-64
+zip_keys:
+- - python
+  - numpy
+  - python_impl

--- a/README.md
+++ b/README.md
@@ -63,17 +63,17 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_64_numpy1.26python3.12.____cpythonpython_implcpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1887&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/scipy-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.26python3.12.____cpythonpython_implcpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>linux_aarch64_numpy1.22python3.10.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1887&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/scipy-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_numpy1.22python3.10.____cpythonpython_implcpython" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
-              <td>linux_aarch64_numpy1.22python3.9.____73_pypypython_implpypy</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1887&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/scipy-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_numpy1.22python3.9.____73_pypypython_implpypy" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -91,17 +91,17 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_aarch64_numpy1.26python3.12.____cpythonpython_implcpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1887&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/scipy-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_numpy1.26python3.12.____cpythonpython_implcpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>linux_ppc64le_numpy1.22python3.10.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1887&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/scipy-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_numpy1.22python3.10.____cpythonpython_implcpython" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
-              <td>linux_ppc64le_numpy1.22python3.9.____73_pypypython_implpypy</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1887&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/scipy-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_numpy1.22python3.9.____73_pypypython_implpypy" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -116,6 +116,13 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1887&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/scipy-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_numpy1.23python3.11.____cpythonpython_implcpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_numpy1.26python3.12.____cpythonpython_implcpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1887&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/scipy-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_numpy1.26python3.12.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -147,6 +154,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>osx_64_numpy1.26python3.12.____cpythonpython_implcpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1887&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/scipy-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.26python3.12.____cpythonpython_implcpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>osx_arm64_numpy1.22python3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1887&branchName=main">
@@ -165,6 +179,13 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1887&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/scipy-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_numpy1.23python3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_numpy1.26python3.12.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1887&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/scipy-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_numpy1.26python3.12.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -193,6 +214,13 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1887&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/scipy-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.23python3.11.____cpythonpython_implcpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_numpy1.26python3.12.____cpythonpython_implcpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1887&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/scipy-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.26python3.12.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -25,7 +25,7 @@ FOR /F "tokens=* USEBACKQ" %%F IN (`clang.exe -dumpversion`) DO (
 :: https://github.com/llvm/llvm-project/issues/63741
 set "FFLAGS=-D_CRT_SECURE_NO_WARNINGS -D_MT -D_DLL --target=x86_64-pc-windows-msvc -nostdlib"
 set "LDFLAGS=--target=x86_64-pc-windows-msvc -nostdlib -Xclang --dependent-lib=msvcrt -fuse-ld=lld"
-set "LDFLAGS=%LDFLAGS% -Wl,-defaultlib:%LIBRARY_PREFIX%/lib/clang/!CLANG_VER!/lib/windows/clang_rt.builtins-x86_64.lib"
+set "LDFLAGS=%LDFLAGS% -Wl,-defaultlib:%BUILD_PREFIX%/Library/lib/clang/!CLANG_VER!/lib/windows/clang_rt.builtins-x86_64.lib"
 
 :: see explanation here:
 :: https://github.com/conda-forge/scipy-feedstock/pull/253#issuecomment-1732578945

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -2,6 +2,14 @@
 
 mkdir builddir
 
+:: check if clang-cl is on path as required
+clang-cl.exe --version
+if %ERRORLEVEL% neq 0 exit 1
+
+:: set compilers to clang-cl
+set "CC=clang-cl"
+set "CXX=clang-cl"
+
 :: flang 17 still uses "temporary" name
 set "FC=flang-new"
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -2,6 +2,9 @@
 
 mkdir builddir
 
+:: flang 17 still uses "temporary" name
+set "FC=flang-new"
+
 :: -wnx flags mean: --wheel --no-isolation --skip-dependency-check
 %PYTHON% -m build -w -n -x ^
     -Cbuilddir=builddir ^

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,9 +1,0 @@
-@echo on
-setlocal enabledelayedexpansion
-
-:: copy %SRC_DIR%/base somewhere to be able to hard-reset state in build-output.bat
-mkdir .\backup
-robocopy base backup /E >nul
-:: for whatever reason, robocopy returns 1 in case of success, see
-:: https://learn.microsoft.com/en-us/troubleshoot/windows-server/backup-and-storage/return-codes-used-robocopy-utility
-if %ERRORLEVEL% neq 1 exit 1

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -10,5 +10,6 @@ set "FC=flang-new"
     -Cbuilddir=builddir ^
     -Csetup-args=-Dblas=blas ^
     -Csetup-args=-Dlapack=lapack ^
+    -Csetup-args=-Dfortran_std=none ^
     -Csetup-args=-Duse-g77-abi=true
 if %ERRORLEVEL% neq 0 (type builddir\meson-logs\meson-log.txt && exit 1)

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,0 +1,11 @@
+@echo on
+
+mkdir builddir
+
+:: -wnx flags mean: --wheel --no-isolation --skip-dependency-check
+%PYTHON% -m build -w -n -x ^
+    -Cbuilddir=builddir ^
+    -Csetup-args=-Dblas=blas ^
+    -Csetup-args=-Dlapack=lapack ^
+    -Csetup-args=-Duse-g77-abi=true
+if %ERRORLEVEL% neq 0 (type builddir\meson-logs\meson-log.txt && exit 1)

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -13,6 +13,13 @@ set "CXX=clang-cl"
 :: flang 17 still uses "temporary" name
 set "FC=flang-new"
 
+:: set up clang-cl correctly, see
+:: https://github.com/conda-forge/clang-win-activation-feedstock/blob/main/recipe/activate-clang_win-64.sh
+set "CPPFLAGS=-D_CRT_SECURE_NO_WARNINGS -D_MT -D_DLL --target=x86_64-pc-windows-msvc -nostdlib -Xclang --dependent-lib=msvcrt -fuse-ld=lld -fno-aligned-allocation"
+set "FFLAGS=-D_CRT_SECURE_NO_WARNINGS -D_MT -D_DLL --target=x86_64-pc-windows-msvc -nostdlib"
+set "LDFLAGS=--target=x86_64-pc-windows-msvc -nostdlib -Xclang --dependent-lib=msvcrt -fuse-ld=lld"
+set "LDFLAGS=%LDFLAGS% -Wl,-defaultlib:%LIBRARY_PREFIX%/lib/clang/17.0.0/lib/windows/clang_rt.builtins-x86_64.lib"
+
 :: -wnx flags mean: --wheel --no-isolation --skip-dependency-check
 %PYTHON% -m build -w -n -x ^
     -Cbuilddir=builddir ^

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -15,10 +15,14 @@ set "FC=flang-new"
 
 :: set up clang-cl correctly, see
 :: https://github.com/conda-forge/clang-win-activation-feedstock/blob/main/recipe/activate-clang_win-64.sh
-set "CPPFLAGS=-D_CRT_SECURE_NO_WARNINGS -D_MT -D_DLL --target=x86_64-pc-windows-msvc -nostdlib -Xclang --dependent-lib=msvcrt -fuse-ld=lld -fno-aligned-allocation"
+set "CPPFLAGS=-D_CRT_SECURE_NO_WARNINGS -D_MT -D_DLL --target=x86_64-pc-windows-msvc -Xclang --dependent-lib=msvcrt -fuse-ld=lld"
 set "FFLAGS=-D_CRT_SECURE_NO_WARNINGS -D_MT -D_DLL --target=x86_64-pc-windows-msvc -nostdlib"
 set "LDFLAGS=--target=x86_64-pc-windows-msvc -nostdlib -Xclang --dependent-lib=msvcrt -fuse-ld=lld"
 set "LDFLAGS=%LDFLAGS% -Wl,-defaultlib:%LIBRARY_PREFIX%/lib/clang/17.0.0/lib/windows/clang_rt.builtins-x86_64.lib"
+
+:: see explanation here:
+:: https://github.com/conda-forge/scipy-feedstock/pull/253#issuecomment-1732578945
+set "MESON_RSP_THRESHOLD=320000"
 
 :: -wnx flags mean: --wheel --no-isolation --skip-dependency-check
 %PYTHON% -m build -w -n -x ^

--- a/recipe/build-output.bat
+++ b/recipe/build-output.bat
@@ -1,15 +1,6 @@
 @echo on
 setlocal enabledelayedexpansion
 
-REM these are done automatically for openblas by numpy.distutils, but
-REM not for our blas libraries
-echo %LIBRARY_LIB%\blas.lib > %LIBRARY_LIB%\blas.fobjects
-echo %LIBRARY_LIB%\blas.lib > %LIBRARY_LIB%\blas.cobjects
-echo %LIBRARY_LIB%\cblas.lib > %LIBRARY_LIB%\cblas.fobjects
-echo %LIBRARY_LIB%\cblas.lib > %LIBRARY_LIB%\cblas.cobjects
-echo %LIBRARY_LIB%\lapack.lib > %LIBRARY_LIB%\lapack.fobjects
-echo %LIBRARY_LIB%\lapack.lib > %LIBRARY_LIB%\lapack.cobjects
-
 REM Set a few environment variables that are not set due to
 REM https://github.com/conda/conda-build/issues/3993
 set PIP_NO_BUILD_ISOLATION=True
@@ -18,58 +9,14 @@ set PIP_IGNORE_INSTALLED=True
 set PIP_NO_INDEX=True
 set PYTHONDONTWRITEBYTECODE=True
 
-REM Use the G77 ABI wrapper everywhere so that the underlying blas implementation
-REM can have a G77 ABI (currently only MKL)
-set SCIPY_USE_G77_ABI_WRAPPER=1
-
-REM Need to get numpy include paths, which also requires the one for Python
-FOR /F "tokens=* USEBACKQ" %%F IN (`python -c "import numpy; print(numpy.get_include())"`) DO (
-    SET "NP_INC=%%F"
+:: `pip install dist\numpy*.whl` does not work on windows,
+:: so use a loop; there's only one wheel in dist/ anyway
+for /f %%f in ('dir /b /S .\dist') do (
+    REM need to use force to reinstall the tests the second time
+    REM (otherwise pip thinks the package is installed already)
+    pip install %%f --force-reinstall
+    if %ERRORLEVEL% neq 0 exit 1
 )
-FOR /F "tokens=* USEBACKQ" %%F IN (`python -c "import sysconfig; print(sysconfig.get_path('include'))"`) DO (
-    SET "PY_INC=%%F"
-)
-
-REM This builds a Fortran file which calls a C function, but numpy.distutils
-REM creates an isolated DLL for these fortran functions and therefore it doesn't
-REM see these C functions. workaround this by compiling it ourselves and
-REM sneaking it with the blas libraries
-REM TODO: rewrite wrap_g77_abi.f with iso_c_binding when the compiler supports it
-cl.exe /I%NP_INC% /I%PY_INC% scipy\_build_utils\src\wrap_g77_abi_c.c -c /MD
-if %ERRORLEVEL% neq 0 exit 1
-echo. > scipy\_build_utils\src\wrap_g77_abi_c.c
-echo %SRC_DIR%\wrap_g77_abi_c.obj >> %LIBRARY_LIB%\lapack.fobjects
-echo %SRC_DIR%\wrap_g77_abi_c.obj >> %LIBRARY_LIB%\lapack.cobjects
-
-REM Add a file to load the fortran wrapper libraries in scipy/.libs
-del scipy\_distributor_init.py
-if %ERRORLEVEL% neq 0 exit 1
-copy %RECIPE_DIR%\_distributor_init.py scipy\
-if %ERRORLEVEL% neq 0 exit 1
-
-REM check if clang-cl is on path as required
-clang-cl.exe --version
-if %ERRORLEVEL% neq 0 exit 1
-
-REM set compilers to clang-cl
-set "CC=clang-cl"
-set "CXX=clang-cl"
-
-REM clang-cl & gfortran use different LDFLAGS; unset it
-set "LDFLAGS="
-REM don't add d1trimfile option because clang doesn't recognize it.
-set "SRC_DIR="
-
-%PYTHON% _setup.py install --single-version-externally-managed --record=record.txt
-if %ERRORLEVEL% neq 0 exit 1
-
-REM make sure these aren't packaged
-del %LIBRARY_LIB%\blas.fobjects
-del %LIBRARY_LIB%\blas.cobjects
-del %LIBRARY_LIB%\cblas.fobjects
-del %LIBRARY_LIB%\cblas.cobjects
-del %LIBRARY_LIB%\lapack.fobjects
-del %LIBRARY_LIB%\lapack.cobjects
 
 FOR /F "tokens=* USEBACKQ" %%F IN (`python -c "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX'))"`) DO (
     SET EXT_SUFFIX=%%F
@@ -97,7 +44,3 @@ if "%PKG_NAME%"=="scipy" (
     REM copy "test" with informative error message into installation
     copy %RECIPE_DIR%\test_conda_forge_packaging.py %SP_DIR%\scipy\_lib
 )
-
-:: clean up between invocations
-rmdir /s /q build
-del wrap_g77_abi_c.obj

--- a/recipe/build-output.bat
+++ b/recipe/build-output.bat
@@ -1,9 +1,6 @@
 @echo on
 setlocal enabledelayedexpansion
 
-:: for reason see source section in meta.yaml & below
-cd base
-
 REM these are done automatically for openblas by numpy.distutils, but
 REM not for our blas libraries
 echo %LIBRARY_LIB%\blas.lib > %LIBRARY_LIB%\blas.fobjects
@@ -41,8 +38,8 @@ REM TODO: rewrite wrap_g77_abi.f with iso_c_binding when the compiler supports i
 cl.exe /I%NP_INC% /I%PY_INC% scipy\_build_utils\src\wrap_g77_abi_c.c -c /MD
 if %ERRORLEVEL% neq 0 exit 1
 echo. > scipy\_build_utils\src\wrap_g77_abi_c.c
-echo %SRC_DIR%\base\wrap_g77_abi_c.obj >> %LIBRARY_LIB%\lapack.fobjects
-echo %SRC_DIR%\base\wrap_g77_abi_c.obj >> %LIBRARY_LIB%\lapack.cobjects
+echo %SRC_DIR%\wrap_g77_abi_c.obj >> %LIBRARY_LIB%\lapack.fobjects
+echo %SRC_DIR%\wrap_g77_abi_c.obj >> %LIBRARY_LIB%\lapack.cobjects
 
 REM Add a file to load the fortran wrapper libraries in scipy/.libs
 del scipy\_distributor_init.py
@@ -99,13 +96,8 @@ if "%PKG_NAME%"=="scipy" (
 
     REM copy "test" with informative error message into installation
     copy %RECIPE_DIR%\test_conda_forge_packaging.py %SP_DIR%\scipy\_lib
-
-    REM hard-reset %SRC_DIR%\base to original state; see prep in bld.bat
-    cd ..
-    rmdir /s /q base
-    REM both `move` and `robocopy` may spuriously fail to copy for some inane reason;
-    REM use `robocopy` because it should fail less than `move`, and it provides a log.
-    REM return code 1 means success, for anything else show log (though we'll know
-    REM anyway, because if the copy fails, compilation for `scipy-tests` will break).
-    (robocopy backup base /E /MOVE >copylog) || if !ERRORLEVEL! neq 1 type copylog
 )
+
+:: clean up between invocations
+rmdir /s /q build
+del wrap_g77_abi_c.obj

--- a/recipe/build-output.sh
+++ b/recipe/build-output.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -ex
 
-# for reason see source section in meta.yaml
-cd base
-
 # Set a few environment variables that are not set due to
 # https://github.com/conda/conda-build/issues/3993
 export PIP_NO_BUILD_ISOLATION=True

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -ex
 
-# for reason see source section in meta.yaml
-cd base
-
 mkdir builddir
 
 # HACK: extend $CONDA_PREFIX/meson_cross_file that's created in

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,7 +1,2 @@
-c_compiler:                    # [win]
-  - vs2019                     # [win]
-cxx_compiler:                  # [win]
-  - vs2019                     # [win]
-
 channel_sources:                            # [win]
   - conda-forge/label/llvm_rc,conda-forge   # [win]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -2,3 +2,6 @@ c_compiler:                    # [win]
   - vs2019                     # [win]
 cxx_compiler:                  # [win]
   - vs2019                     # [win]
+
+channel_sources:                            # [win]
+  - conda-forge/label/llvm_rc,conda-forge   # [win]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,2 @@
-channel_sources:                            # [win]
-  - conda-forge/label/llvm_rc,conda-forge   # [win]
+channel_sources:                                                        # [win]
+  - conda-forge/label/llvm_rc,conda-forge/label/meson_dev,conda-forge   # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -208,6 +208,8 @@ outputs:
         - python
         - pip
         - numpy
+        # make link check happy
+        - liblapack
       run:
         - {{ pin_subpackage('scipy', exact=True) }}
         - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,24 +14,22 @@ source:
   # the submodules (not in tarball due to dear-github/dear-github#214)
   - url: https://github.com/scipy/scipy/archive/refs/tags/v{{ version }}.tar.gz
     sha256: 86712f1dff2cf674d823ad5489db54928b44149f76d7ba891ad19a6ae118abcf
-    # need separate folder to do full reset on windows, see build-output.bat
-    folder: base
     patches:
       - patches/0001-remove-comment-that-breaks-parsing.patch
   # https://github.com/scipy/scipy/tree/v{{ version }}/scipy/_lib
   - git_url: https://github.com/boostorg/math.git
     git_rev: 298a243ccd3639b6eaa59bcdab7ab9d5f008fb36
-    folder: base/scipy/_lib/boost_math
+    folder: scipy/_lib/boost_math
   - git_url: https://github.com/scipy/highs.git
     git_rev: 4a122958a82e67e725d08153e099efe4dad099a2
-    folder: base/scipy/_lib/highs
+    folder: scipy/_lib/highs
   - git_url: https://github.com/scipy/unuran.git
     git_rev: 81a1fd118b326880e00cc7d8989fb063782a6bdd
-    folder: base/scipy/_lib/unuran
+    folder: scipy/_lib/unuran
   # https://github.com/scipy/scipy/tree/v{{ version }}/scipy/sparse/linalg/_propack
   - git_url: https://github.com/scipy/PROPACK.git
     git_rev: 96f6800451372dd003e627bbfd732937ac0c685e
-    folder: base/scipy/sparse/linalg/_propack/PROPACK
+    folder: scipy/sparse/linalg/_propack/PROPACK
 
 build:
   number: 0
@@ -292,7 +290,7 @@ outputs:
 about:
   home: http://www.scipy.org/
   license: BSD-3-Clause
-  license_file: base/LICENSE.txt
+  license_file: LICENSE.txt
   summary: Scientific Library for Python
   description: |
     SciPy is a Python-based ecosystem of open-source software for mathematics,

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,6 +56,7 @@ requirements:
     # use llvm linker for both of the above
     - lld                                    # [win]
   host:
+    - compiler-rt                            # [win]
     - libblas
     - libcblas
     - liblapack

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,7 @@ source:
     folder: scipy/sparse/linalg/_propack/PROPACK
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<39]
   # pypy on aarch/ppc is un(der)maintained and currently broken, see
   # https://github.com/conda-forge/pypy3.6-feedstock/issues/111

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -229,7 +229,7 @@ outputs:
         {% set tests_to_skip = tests_to_skip + " or (test_lsq_linear and test_large_rank_deficient)" %}   # [aarch64 or ppc64le]
         {% set tests_to_skip = tests_to_skip + " or (test_iterative and test_precond_inverse[case1])" %}  # [aarch64 or ppc64le]
         {% set tests_to_skip = tests_to_skip + " or (test_optimize and TestBrute and test_workers)" %}    # [aarch64 or ppc64le]
-        {% set tests_to_skip = tests_to_skip + " or (TestLevyStable and test_location_scale[pdf-1])" %}   # [aarch64 or ppc64le]
+        {% set tests_to_skip = tests_to_skip + " or (TestLevyStable and test_location_scale)" %}          # [aarch64 or ppc64le]
         {% set tests_to_skip = tests_to_skip + " or (TestShgoArguments and test_19_parallelization)" %}   # [aarch64 or ppc64le]
         # tests that run into timeouts (set in scipy test suite) in emulation
         {% set tests_to_skip = tests_to_skip + " or (test_propack and test_examples)" %}                  # [aarch64 or ppc64le]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,24 +49,29 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - {{ compiler('fortran') }}              # [unix]
+    # pythran code needs clang-cl on windows
+    - clang                                  # [win]
+    # use flang as fortran compiler on windows (uses clang driver)
+    - flang                                  # [win]
+    # use llvm linker for both of the above
+    - lld                                    # [win]
   host:
     - libblas
     - libcblas
     - liblapack
     - python
     - cython
-    - meson-python    # [unix]
-    - ninja           # [unix]
-    - pkg-config      # [unix]
-    - python-build    # [unix]
+    - meson-python
+    - ninja
+    - pkg-config
+    - python-build
     - pybind11
     - pythran
     - numpy
     - pip
 
-# for unix, the top-level build.sh builds scipy, and then build-output.sh
-# installs the files for the respective component; on windows, we currently
-# don't have a nice separation into build & install steps, so build twice...
+# the top-level build.{sh,bat} builds scipy, and then
+# build-output.{sh,bat} installs the files
 outputs:
   - name: scipy
     script: build-output.sh   # [not win]
@@ -76,28 +81,20 @@ outputs:
       build:
         - python                                 # [build_platform != target_platform]
         - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-        # unix only needs these for the strong run exports
+        # only need these for the strong run exports
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         - {{ compiler('fortran') }}              # [unix]
-        # pythran code needs clang-cl on windows
-        - clang                                  # [win]
-        # WARNING: It's not recommended to use these MinGW compilers with python extensions
-        # numpy.distutils has a complex mechanism to facilitate mixing gfortran and MSVC
-        # https://pav.iki.fi/blog/2017-10-08/pywingfortran.html#building-python-wheels-with-fortran-for-windows
-        - {{ compiler('m2w64_fortran') }}        # [win]
       host:
         - libblas
         - libcblas
         - liblapack
         - python
-        - setuptools <60  # [win]
-        - cython <3       # [win]
         - cython
-        - meson-python    # [unix]
-        - ninja           # [unix]
-        - pkg-config      # [unix]
-        - python-build    # [unix]
+        - meson-python
+        - ninja
+        - pkg-config
+        - python-build
         - pybind11
         - pythran
         - numpy
@@ -197,31 +194,16 @@ outputs:
       build:
         - python                                 # [build_platform != target_platform]
         - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-        # unix only needs these for the strong run exports
+        # only need these for the strong run exports
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         - {{ compiler('fortran') }}              # [unix]
-        # pythran code needs clang-cl on windows
-        - clang                                  # [win]
-        # WARNING: It's not recommended to use these MinGW compilers with python extensions
-        # numpy.distutils has a complex mechanism to facilitate mixing gfortran and MSVC
-        # https://pav.iki.fi/blog/2017-10-08/pywingfortran.html#building-python-wheels-with-fortran-for-windows
-        - {{ compiler('m2w64_fortran') }}        # [win]
       host:
         - {{ pin_subpackage('scipy', exact=True) }}
-        # need to repeat host deps on windows because we have to do a full rebuild here;
-        # on unix we need a minimum as well so that installation of the wheel will work
+        # need a minimum for (re-)installation of wheel
         - python
         - pip
         - numpy
-        - libblas         # [win]
-        - libcblas        # [win]
-        - liblapack       # [win]
-        - setuptools <60  # [win]
-        - cython <3       # [win]
-        - pybind11        # [win]
-        - pythran         # [win]
-        - numpy           # [win]
       run:
         - {{ pin_subpackage('scipy', exact=True) }}
         - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -225,6 +225,8 @@ outputs:
         {% set tests_to_skip = tests_to_skip + " or test_x0_equals_Mb[bicgstab" %}
         # scipy/scipy#16927
         {% set tests_to_skip = tests_to_skip + " or test_failure_to_run_iterations" %}  # [linux]
+        # scipy/scipy#19337
+        {% set tests_to_skip = tests_to_skip + " or (TestLevyStable and test_distribution_outside_)" %}   # [aarch64 or ppc64le]
         # on the slowest agents, these tests take more than 20min in emulation
         {% set tests_to_skip = tests_to_skip + " or (test_lsq_linear and test_large_rank_deficient)" %}   # [aarch64 or ppc64le]
         {% set tests_to_skip = tests_to_skip + " or (test_iterative and test_precond_inverse[case1])" %}  # [aarch64 or ppc64le]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,6 +34,9 @@ source:
 build:
   number: 0
   skip: true  # [py<39]
+  # pypy on aarch/ppc is un(der)maintained and currently broken, see
+  # https://github.com/conda-forge/pypy3.6-feedstock/issues/111
+  skip: true  # [(aarch64 or ppc64le) and python_impl == "pypy"]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,7 @@ requirements:
   build:
     - python                                 # [build_platform != target_platform]
     - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-    - cython                                 # [build_platform != target_platform]
+    - cython <3                              # [build_platform != target_platform]
     - numpy                                  # [build_platform != target_platform]
     - pybind11                               # [build_platform != target_platform]
     - meson-python                           # [build_platform != target_platform]
@@ -61,7 +61,7 @@ requirements:
     - libcblas
     - liblapack
     - python
-    - cython
+    - cython <3
     - meson-python
     - ninja
     - pkg-config


### PR DESCRIPTION
This is a cleaned-up version of #246, taking into account learnings & patches contributed by several people (also in #252 & #253), some of which were directly upstreamed to scipy and made it into 1.11.3 already.

Requires builds from https://github.com/conda-forge/flang-feedstock/pull/28 & ~https://github.com/conda-forge/meson-feedstock/pull/89~ https://github.com/conda-forge/meson-feedstock/pull/92 which are currently only available under `llvm_rc` and `meson_dev` labels. This will hopefully improve soon.

It's likely that this will still need some work around compiler-activation, flags, etc.; but with a passing test suite in #246, we should be good for more in-depth review.

Closes #253
Closes #252 
Closes #246 
Closes #213
Closes #164