### PR TITLE
backport patch for spurious warning on windows

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,11 @@ source:
   # the submodules (not in tarball due to dear-github/dear-github#214)
   - url: https://github.com/scipy/scipy/archive/refs/tags/v{{ version }}.tar.gz
     sha256: 2ade75a1993b703a4cbe43b32f531feb291918cfd6d220778e107cb50b3e0266
+    patches:
+      # backport https://github.com/scipy/scipy/pull/19937
+      - patches/0001-TST-Add-RNG-seeds-for-TestInvgauss-and-TestLaplace-1.patch
+      # backport https://github.com/scipy/scipy/pull/19945
+      - patches/0002-BLD-fix-issue-with-escape-sequences-in-__config__.py.patch
   # https://github.com/scipy/scipy/tree/v{{ version }}/scipy/_lib
   - git_url: https://github.com/data-apis/array-api-compat.git
     git_rev: affd3a56927d3d1c178023121f43c9fa624eced0
@@ -33,7 +38,7 @@ source:
     folder: scipy/sparse/linalg/_propack/PROPACK
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<39]
   # pypy on aarch/ppc is un(der)maintained and currently broken, see
   # https://github.com/conda-forge/pypy3.6-feedstock/issues/111

--- a/recipe/patches/0001-TST-Add-RNG-seeds-for-TestInvgauss-and-TestLaplace-1.patch
+++ b/recipe/patches/0001-TST-Add-RNG-seeds-for-TestInvgauss-and-TestLaplace-1.patch
@@ -1,0 +1,47 @@
+From fb621226e50d29e38350ec9102b746b275a8f3f6 Mon Sep 17 00:00:00 2001
+From: Ben Mares <services-git-throwaway1@tensorial.com>
+Date: Mon, 22 Jan 2024 00:03:12 +0100
+Subject: [PATCH 1/2] TST: Add RNG seeds for TestInvgauss and TestLaplace
+ (#19937)
+
+---
+ scipy/stats/tests/test_distributions.py | 11 ++++++++---
+ 1 file changed, 8 insertions(+), 3 deletions(-)
+
+diff --git a/scipy/stats/tests/test_distributions.py b/scipy/stats/tests/test_distributions.py
+index 3aa62e75d3..fa087e1d78 100644
+--- a/scipy/stats/tests/test_distributions.py
++++ b/scipy/stats/tests/test_distributions.py
+@@ -2841,8 +2841,9 @@ class TestInvgauss:
+     @pytest.mark.parametrize("rvs_mu,rvs_loc,rvs_scale",
+                              [(2, 0, 1), (6.311, 3.225, 4.520)])
+     def test_fit_MLE_comp_optimizer(self, rvs_mu, rvs_loc, rvs_scale):
++        rng = np.random.RandomState(1234)
+         data = stats.invgauss.rvs(size=100, mu=rvs_mu,
+-                                  loc=rvs_loc, scale=rvs_scale)
++                                  loc=rvs_loc, scale=rvs_scale, random_state=rng)
+ 
+         super_fit = super(type(stats.invgauss), stats.invgauss).fit
+         # fitting without `floc` uses superclass fit method
+@@ -2952,7 +2953,9 @@ class TestLaplace:
+     def test_fit(self, rvs_loc, rvs_scale):
+         # tests that various inputs follow expected behavior
+         # for a variety of `loc` and `scale`.
+-        data = stats.laplace.rvs(size=100, loc=rvs_loc, scale=rvs_scale)
++        rng = np.random.RandomState(1234)
++        data = stats.laplace.rvs(size=100, loc=rvs_loc, scale=rvs_scale,
++                                 random_state=rng)
+ 
+         # MLE estimates are given by
+         loc_mle = np.median(data)
+@@ -2996,7 +2999,9 @@ class TestLaplace:
+                                                    (10, 5),
+                                                    (0.5, 0.2)])
+     def test_fit_MLE_comp_optimizer(self, rvs_loc, rvs_scale):
+-        data = stats.laplace.rvs(size=1000, loc=rvs_loc, scale=rvs_scale)
++        rng = np.random.RandomState(1234)
++        data = stats.laplace.rvs(size=1000, loc=rvs_loc, scale=rvs_scale,
++                                 random_state=rng)
+ 
+         # the log-likelihood function for laplace is given by
+         def ll(loc, scale, data):

--- a/recipe/patches/0002-BLD-fix-issue-with-escape-sequences-in-__config__.py.patch
+++ b/recipe/patches/0002-BLD-fix-issue-with-escape-sequences-in-__config__.py.patch
@@ -1,0 +1,124 @@
+From 3b0f2f05ea3eda4e6c1fe9c368376a0b7eaece1d Mon Sep 17 00:00:00 2001
+From: Ralf Gommers <ralf.gommers@gmail.com>
+Date: Mon, 22 Jan 2024 23:30:40 +0100
+Subject: [PATCH 2/2] BLD: fix issue with escape sequences in `__config__.py`
+
+Reported in https://github.com/conda-forge/scipy-feedstock/issues/264:
+linker args contained a `\s` on Windows as part of a path in a linker
+flag.
+
+This is basically the same bug as gh-17936, it was fixed for paths
+in `__config__.py` but not for things like linker flags which usually
+don't contain a path but may do so.
+
+Now turn everything except name/version/found/id, which really should
+not contain escapes, into raw strings.
+
+[skip circle] [skip cirrus]
+---
+ scipy/__config__.py.in | 58 +++++++++++++++++++++---------------------
+ 1 file changed, 29 insertions(+), 29 deletions(-)
+
+diff --git a/scipy/__config__.py.in b/scipy/__config__.py.in
+index fdfd9e64ab..7be746a25b 100644
+--- a/scipy/__config__.py.in
++++ b/scipy/__config__.py.in
+@@ -27,53 +27,53 @@ CONFIG = _cleanup(
+         "Compilers": {
+             "c": {
+                 "name": "@C_COMP@",
+-                "linker": "@C_COMP_LINKER_ID@",
++                "linker": r"@C_COMP_LINKER_ID@",
+                 "version": "@C_COMP_VERSION@",
+-                "commands": "@C_COMP_CMD_ARRAY@",
+-                "args": "@C_COMP_ARGS@",
+-                "linker args": "@C_COMP_LINK_ARGS@",
++                "commands": r"@C_COMP_CMD_ARRAY@",
++                "args": r"@C_COMP_ARGS@",
++                "linker args": r"@C_COMP_LINK_ARGS@",
+             },
+             "cython": {
+-                "name": "@CYTHON_COMP@",
+-                "linker": "@CYTHON_COMP_LINKER_ID@",
+-                "version": "@CYTHON_COMP_VERSION@",
+-                "commands": "@CYTHON_COMP_CMD_ARRAY@",
+-                "args": "@CYTHON_COMP_ARGS@",
+-                "linker args": "@CYTHON_COMP_LINK_ARGS@",
++                "name": r"@CYTHON_COMP@",
++                "linker": r"@CYTHON_COMP_LINKER_ID@",
++                "version": r"@CYTHON_COMP_VERSION@",
++                "commands": r"@CYTHON_COMP_CMD_ARRAY@",
++                "args": r"@CYTHON_COMP_ARGS@",
++                "linker args": r"@CYTHON_COMP_LINK_ARGS@",
+             },
+             "c++": {
+                 "name": "@CPP_COMP@",
+-                "linker": "@CPP_COMP_LINKER_ID@",
++                "linker": r"@CPP_COMP_LINKER_ID@",
+                 "version": "@CPP_COMP_VERSION@",
+-                "commands": "@CPP_COMP_CMD_ARRAY@",
+-                "args": "@CPP_COMP_ARGS@",
+-                "linker args": "@CPP_COMP_LINK_ARGS@",
++                "commands": r"@CPP_COMP_CMD_ARRAY@",
++                "args": r"@CPP_COMP_ARGS@",
++                "linker args": r"@CPP_COMP_LINK_ARGS@",
+             },
+             "fortran": {
+                 "name": "@FORTRAN_COMP@",
+-                "linker": "@FORTRAN_COMP_LINKER_ID@",
++                "linker": r"@FORTRAN_COMP_LINKER_ID@",
+                 "version": "@FORTRAN_COMP_VERSION@",
+-                "commands": "@FORTRAN_COMP_CMD_ARRAY@",
+-                "args": "@FORTRAN_COMP_ARGS@",
+-                "linker args": "@FORTRAN_COMP_LINK_ARGS@",
++                "commands": r"@FORTRAN_COMP_CMD_ARRAY@",
++                "args": r"@FORTRAN_COMP_ARGS@",
++                "linker args": r"@FORTRAN_COMP_LINK_ARGS@",
+             },
+             "pythran": {
+-                "version": "@PYTHRAN_VERSION@",
++                "version": r"@PYTHRAN_VERSION@",
+                 "include directory": r"@PYTHRAN_INCDIR@"
+             },
+         },
+         "Machine Information": {
+             "host": {
+-                "cpu": "@HOST_CPU@",
+-                "family": "@HOST_CPU_FAMILY@",
+-                "endian": "@HOST_CPU_ENDIAN@",
+-                "system": "@HOST_CPU_SYSTEM@",
++                "cpu": r"@HOST_CPU@",
++                "family": r"@HOST_CPU_FAMILY@",
++                "endian": r"@HOST_CPU_ENDIAN@",
++                "system": r"@HOST_CPU_SYSTEM@",
+             },
+             "build": {
+-                "cpu": "@BUILD_CPU@",
+-                "family": "@BUILD_CPU_FAMILY@",
+-                "endian": "@BUILD_CPU_ENDIAN@",
+-                "system": "@BUILD_CPU_SYSTEM@",
++                "cpu": r"@BUILD_CPU@",
++                "family": r"@BUILD_CPU_FAMILY@",
++                "endian": r"@BUILD_CPU_ENDIAN@",
++                "system": r"@BUILD_CPU_SYSTEM@",
+             },
+             "cross-compiled": bool("@CROSS_COMPILED@".lower().replace('false', '')),
+         },
+@@ -85,7 +85,7 @@ CONFIG = _cleanup(
+                 "detection method": "@BLAS_TYPE_NAME@",
+                 "include directory": r"@BLAS_INCLUDEDIR@",
+                 "lib directory": r"@BLAS_LIBDIR@",
+-                "openblas configuration": "@BLAS_OPENBLAS_CONFIG@",
++                "openblas configuration": r"@BLAS_OPENBLAS_CONFIG@",
+                 "pc file directory": r"@BLAS_PCFILEDIR@",
+             },
+             "lapack": {
+@@ -95,7 +95,7 @@ CONFIG = _cleanup(
+                 "detection method": "@LAPACK_TYPE_NAME@",
+                 "include directory": r"@LAPACK_INCLUDEDIR@",
+                 "lib directory": r"@LAPACK_LIBDIR@",
+-                "openblas configuration": "@LAPACK_OPENBLAS_CONFIG@",
++                "openblas configuration": r"@LAPACK_OPENBLAS_CONFIG@",
+                 "pc file directory": r"@LAPACK_PCFILEDIR@",
+             },
+             "pybind11": {


### PR DESCRIPTION
Fixes #264

And while we're at it, backport a PR for the spurious test failures on that crop up on PPC.