### PR TITLE
ignore libflang run-export for scipy-tests

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,9 @@ source:
   # the submodules (not in tarball due to dear-github/dear-github#214)
   - url: https://github.com/scipy/scipy/archive/refs/tags/v{{ version }}.tar.gz
     sha256: ea1c8e3ebe88713063b70ff1b5902400b16131ad1f5b731b6585fb9f5721ed2d
+    patches:
+      # backport https://github.com/scipy/scipy/pull/21069
+      - patches/0001-MAINT-fix-typo-in-small_dynamic_array.h-21069.patch
   # https://github.com/scipy/scipy/tree/v{{ version }}/scipy/_lib
   - git_url: https://github.com/data-apis/array-api-compat.git
     folder: scipy/_lib/array_api_compat

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ source:
     git_rev: a9ed9736ad52ff76ae1777922b700b13ca2bf0ae
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<310]
   # pypy is currently broken and on its way out anyway
   skip: true  # [python_impl == "pypy"]
@@ -210,6 +210,9 @@ outputs:
   - name: scipy-tests
     script: build-output.sh   # [not win]
     script: build-output.bat  # [win]
+    build:
+      ignore_run_exports:     # [win]
+        - libflang            # [win]
     requirements:
       build:
         - python                                 # [build_platform != target_platform]

--- a/recipe/patches/0001-MAINT-fix-typo-in-small_dynamic_array.h-21069.patch
+++ b/recipe/patches/0001-MAINT-fix-typo-in-small_dynamic_array.h-21069.patch
@@ -1,0 +1,31 @@
+From 91c4074b0eb9e4f56e3c182e873f16bdbd83c11e Mon Sep 17 00:00:00 2001
+From: h-vetinari <h.vetinari@gmx.com>
+Date: Sun, 30 Jun 2024 07:33:27 +1100
+Subject: [PATCH] MAINT: fix typo in small_dynamic_array.h (#21069)
+
+on clang-19, this causes:
+```
+../scipy/_lib/_uarray/small_dynamic_array.h(145,18): error: reference to non-static member function must be called
+  145 |     size_ = copy.size;
+      |             ~~~~~^~~~
+1 error generated.
+```
+I'm not sure how previous versions (much less other compilers) dealt with this,
+as it seems that the `SmallDynamicArray` class has no `size` member or field at all.
+---
+ scipy/_lib/_uarray/small_dynamic_array.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/scipy/_lib/_uarray/small_dynamic_array.h b/scipy/_lib/_uarray/small_dynamic_array.h
+index b6c46d7c44..351b5d8fc6 100644
+--- a/scipy/_lib/_uarray/small_dynamic_array.h
++++ b/scipy/_lib/_uarray/small_dynamic_array.h
+@@ -142,7 +142,7 @@ public:
+ 
+     clear();
+ 
+-    size_ = copy.size;
++    size_ = copy.size_;
+     try {
+       allocate();
+     } catch (...) {


### PR DESCRIPTION
A small fix for an unintentional change introduced by https://github.com/conda-forge/scipy-feedstock/commit/3b582be8b3642857c5d67335d49fe2ee3184c280; plus pick up a fix we'll need for #269 